### PR TITLE
fix(sharepoint): correct syntax error in GraphListApiProvider

### DIFF
--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/GraphListApiProvider.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/GraphListApiProvider.java
@@ -59,7 +59,7 @@ public class GraphListApiProvider implements SharePointListApiProvider {
             metadata.getListId(),
             metadata.getListName(),
             metadata.getDisplayName(),
-            "" // Description not available in SharePointListMetadata));
+            "")); // Description not available in SharePointListMetadata
       }
 
       return result;


### PR DESCRIPTION
Fixed misplaced closing parenthesis in the return statement that was causing a compilation error when creating SharePointListInfo objects.

🤖 Generated with [Claude Code](https://claude.ai/code)