### PR TITLE
fix(etl): honor enabledTables + bounded download read-timeout/retry (lands loop + hang fixes)

### DIFF
--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/SchemaConfig.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/SchemaConfig.java
@@ -12,9 +12,11 @@ package org.apache.calcite.adapter.file.etl;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Configuration for a complete schema with tables and lifecycle hooks.
@@ -276,6 +278,26 @@ public class SchemaConfig {
             tables.add(tableConfig);
           }
         }
+      }
+      // Honor enabledTables (typically set from the operand): when non-empty, process only the
+      // named ETL pipelines. Views and source-less/non-hooks tables were already excluded above,
+      // so this only narrows the ETL set — a worker that scopes each model to a subset (e.g. lands)
+      // no longer re-runs every table on every invocation. Empty/absent ⇒ all tables (no filter).
+      Object enabledTablesObj = map.get("enabledTables");
+      if (enabledTablesObj instanceof List && !((List<?>) enabledTablesObj).isEmpty()) {
+        Set<String> enabled = new HashSet<String>();
+        for (Object o : (List<?>) enabledTablesObj) {
+          if (o != null) {
+            enabled.add(String.valueOf(o));
+          }
+        }
+        List<EtlPipelineConfig> filtered = new ArrayList<EtlPipelineConfig>();
+        for (EtlPipelineConfig t : tables) {
+          if (enabled.contains(t.getName())) {
+            filtered.add(t);
+          }
+        }
+        tables = filtered;
       }
       builder.tables(tables);
     }

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/SchemaLifecycleProcessor.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/SchemaLifecycleProcessor.java
@@ -811,12 +811,42 @@ public class SchemaLifecycleProcessor {
    */
   private void downloadBulkFile(String url, String cachePath, StorageProvider storage)
       throws IOException {
+    final int maxAttempts = 4;
+    IOException last = null;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        downloadBulkFileOnce(url, cachePath, storage);
+        return;
+      } catch (IOException e) {
+        last = e;
+        if (attempt < maxAttempts) {
+          long backoffMs = 2000L * attempt;
+          LOGGER.warn("Bulk download attempt {}/{} failed for {} ({}); retrying in {}ms",
+              attempt, maxAttempts, url, e.getMessage(), backoffMs);
+          try {
+            Thread.sleep(backoffMs);
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during bulk download retry backoff for " + url, ie);
+          }
+        }
+      }
+    }
+    throw new IOException("Bulk download failed after " + maxAttempts + " attempts for " + url, last);
+  }
+
+  /** Single bulk-download attempt — see {@link #downloadBulkFile} for the retrying wrapper. */
+  private void downloadBulkFileOnce(String url, String cachePath, StorageProvider storage)
+      throws IOException {
     // Fetch the raw bytes from URL
     java.net.URL urlObj = java.net.URI.create(url).toURL();
     java.net.HttpURLConnection conn = (java.net.HttpURLConnection) urlObj.openConnection();
     conn.setRequestMethod("GET");
     conn.setConnectTimeout(30000);
-    conn.setReadTimeout(300000); // 5 min read timeout for large files
+    // Between-bytes read timeout: a healthy stream never idles this long, so 2 minutes of silence
+    // means the upstream stalled — fail fast and let the retry wrapper re-request rather than
+    // hanging for minutes (seen on FEC / FIA / TIGER / NOAA bulk downloads).
+    conn.setReadTimeout(120000);
     conn.setRequestProperty("User-Agent",
         "Apache-Calcite-DataAdapter/1.0 (https://calcite.apache.org; data-analysis-tool)");
 

--- a/govdata/scripts/parallel/worker-lands.sh
+++ b/govdata/scripts/parallel/worker-lands.sh
@@ -104,6 +104,12 @@ case "$MODE" in
       '"nps_visitation"' "$START" "$END"
     run_lands_model "lands-historical-revenues" \
       '"onrr_revenues"' "$START" "$END"
+    # USDA FIA tables — per-state fan-out (non-period; inventory_year is a column, not a
+    # dimension). Required by lands_dq.sql. One model so each FIA table is ingested exactly once;
+    # without this (and with enabledTables now honored) they would not be produced at all.
+    run_lands_model "lands-historical-fia" \
+      '"fia_plots", "fia_seedlings", "fia_invasives", "fia_down_woody_debris", "fia_pop_evaluations", "fia_tree_grm"' \
+      "$START" "$END"
     ;;
 
   daily)

--- a/govdata/src/main/java/org/apache/calcite/adapter/govdata/ZipDownloadUtils.java
+++ b/govdata/src/main/java/org/apache/calcite/adapter/govdata/ZipDownloadUtils.java
@@ -124,9 +124,43 @@ public final class ZipDownloadUtils {
    */
   public static void downloadToFile(String url, Map<String, String> headers, File dest)
       throws IOException {
+    final int maxAttempts = 4;
+    IOException last = null;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        downloadToFileOnce(url, headers, dest);
+        return;
+      } catch (IOException e) {
+        last = e;
+        // Remove any partial file so the retry starts clean.
+        if (dest.exists() && !dest.delete()) {
+          LOGGER.warn("Could not delete partial download {} before retry", dest);
+        }
+        if (attempt < maxAttempts) {
+          long backoffMs = 2000L * attempt;
+          LOGGER.warn("Download attempt {}/{} failed for {} ({}); retrying in {}ms",
+              attempt, maxAttempts, url, e.getMessage(), backoffMs);
+          try {
+            Thread.sleep(backoffMs);
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted during download retry backoff for " + url, ie);
+          }
+        }
+      }
+    }
+    throw new IOException("Download failed after " + maxAttempts + " attempts for " + url, last);
+  }
+
+  /** Single download attempt — see {@link #downloadToFile} for the retrying wrapper. */
+  private static void downloadToFileOnce(String url, Map<String, String> headers, File dest)
+      throws IOException {
     HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
     conn.setConnectTimeout(30000);
-    conn.setReadTimeout(600000);
+    // Between-bytes read timeout: a healthy stream delivers data continuously, so 2 minutes of
+    // silence means the upstream server has stalled (seen on FIA datamart / FEC / TIGER / NOAA).
+    // Fail fast here and let the retry wrapper re-request, instead of hanging up to 10 minutes.
+    conn.setReadTimeout(120000);
     conn.setRequestProperty("User-Agent", "Apache-Calcite-GovData/1.0");
     if (headers != null) {
       for (Map.Entry<String, String> h : headers.entrySet()) {


### PR DESCRIPTION
## Summary
Fixes two pre-existing ETL bugs exposed by a full from-scratch all-schemas DQ sweep.

### fix(etl): honor `enabledTables` (loop fix) + lands FIA model
`SchemaConfig.fromMap` now applies `enabledTables` (source-backed tables only; SQL views never dropped). It was set on the operand but never applied in the generic file-ETL path, so lands' ~14 per-table models each re-processed all 14 tables — re-running the FIA 51-state fan-out ~14× (`fia_tree_grm` started 12×), a multi-hour pseudo-loop. Also adds the missing `lands-historical-fia` model (the 6 FIA tables `lands_dq.sql` requires).

### fix(etl): bounded read-timeout + retry on bulk/zip downloads
`downloadBulkFile` (5-min) and `ZipDownloadUtils.downloadToFile` (10-min) had long between-bytes read timeouts and no retry, so a stalled upstream (FEC/FIA/TIGER/NOAA) hung the worker for minutes. Now 2-min between-bytes timeout + 4-attempt backoff retry.

## Verification
`run-all-dq --schema lands --local-jar --etl-resume`: `fia_tree_grm` ran exactly once (was 12×), each model processed only its subset, 0 download hangs, **lands DQ PASS (0 fails, 0 warns; 84 tests)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)