### PR TITLE
perf(dq): per-period freshness, sec_prices bulk gate, tracker compaction consolidation

### DIFF
--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
@@ -107,6 +107,13 @@ public class EtlPipeline {
   private boolean perUnitFreshnessEnabled;
 
   /**
+   * True when a per-unit freshness match is allowed to actually SKIP (vs only probe+capture the
+   * token). Mirrors the pipeline-level gate: under forceReprocessAll (no committed data / cleared
+   * marker) we still probe and persist the token so the NEXT run can skip, but never skip THIS run.
+   */
+  private boolean perUnitFreshnessSkipAllowed;
+
+  /**
    * Per-unit freshness tokens captured during this run, keyed by {@code pipeline::unitKey}.
    * Persisted to the tracker only after a clean commit (no failed batches), mirroring the
    * pipeline-level token persistence, so a partial run never caches a skip-forever token.
@@ -630,10 +637,12 @@ public class EtlPipeline {
       // has not changed. Disabled under forceReprocessAll (no committed data / cleared marker) so a
       // dq-rebuild always re-materializes. Hash-type freshness is post-download (handled later).
       perUnitFreshnessEnabled = hasPeriod
-          && !forceReprocessAll
           && freshnessConfig != null
           && freshnessConfig.getType() != FreshnessConfig.Type.HASH
           && dataSource instanceof HttpSource;
+      // Probe+capture always runs (to seed the token on a cold run); only the skip is gated on
+      // having committed data, exactly like the pipeline-level gate above.
+      perUnitFreshnessSkipAllowed = !forceReprocessAll;
 
       // Phase 4: Create and initialize materialization writer
       MaterializeConfig.Format format = materializeConfig != null
@@ -1718,7 +1727,9 @@ public class EtlPipeline {
         String currentToken = FreshnessCheck.token(
             freshnessConfig, probeResult.getHeaders(), probeResult.getBody(), null);
         String previousToken = incrementalTracker.getFreshnessToken(unitKey);
-        if (previousToken != null && !FreshnessCheck.changed(previousToken, currentToken)) {
+        if (perUnitFreshnessSkipAllowed
+            && previousToken != null
+            && !FreshnessCheck.changed(previousToken, currentToken)) {
           LOGGER.info("Pipeline '{}': per-period freshness UNCHANGED for unit {} (token={}) — "
               + "skipping fetch and write", pipelineName, variables, currentToken);
           return 0;

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -95,6 +96,23 @@ public class EtlPipeline {
 
   /** Lock serializing all writer and tracker operations when parallel threads are active. */
   private final Object writeLock = new Object();
+
+  /**
+   * True when per-period freshness gating is active for this run. Set in {@link #execute()} once
+   * the data source and freshness config are known. When true, {@link #processSingleBatch} probes
+   * each fetch unit's templated source and skips the fetch+write for units whose source is
+   * unchanged since the last clean commit — the per-period analogue of the pipeline-level
+   * freshness gate, which can only probe a single non-templated URL.
+   */
+  private boolean perUnitFreshnessEnabled;
+
+  /**
+   * Per-unit freshness tokens captured during this run, keyed by {@code pipeline::unitKey}.
+   * Persisted to the tracker only after a clean commit (no failed batches), mirroring the
+   * pipeline-level token persistence, so a partial run never caches a skip-forever token.
+   */
+  private final Map<String, String> pendingUnitFreshnessTokens =
+      new ConcurrentHashMap<String, String>();
 
   /**
    * Creates a new ETL pipeline.
@@ -602,6 +620,20 @@ public class EtlPipeline {
           // Probe failure = treat as changed; don't skip
         }
       }
+
+      // Per-period freshness gate enablement. The pipeline-level gate above probes a single
+      // non-templated URL with an empty variable map, so it is a no-op for period tables whose
+      // source URL is templated ({year}, {state_fips}, ...). For those, processSingleBatch probes
+      // each fetch unit's concrete (substituted) URL and skips the fetch+write when unchanged —
+      // this is the "freshness OR period-completion OR both" composition: period-completion drops
+      // already-complete combos upstream; this additionally skips the open period when its source
+      // has not changed. Disabled under forceReprocessAll (no committed data / cleared marker) so a
+      // dq-rebuild always re-materializes. Hash-type freshness is post-download (handled later).
+      perUnitFreshnessEnabled = hasPeriod
+          && !forceReprocessAll
+          && freshnessConfig != null
+          && freshnessConfig.getType() != FreshnessConfig.Type.HASH
+          && dataSource instanceof HttpSource;
 
       // Phase 4: Create and initialize materialization writer
       MaterializeConfig.Format format = materializeConfig != null
@@ -1322,6 +1354,15 @@ public class EtlPipeline {
           LOGGER.info("Pipeline '{}': persisted freshness token after clean commit: {}",
               pipelineName, probedFreshnessToken);
         }
+        // Persist per-period freshness tokens captured this run so the next run can skip
+        // unchanged periods. Same clean-commit guard as the pipeline-level token above.
+        if (!pendingUnitFreshnessTokens.isEmpty()) {
+          for (Map.Entry<String, String> entry : pendingUnitFreshnessTokens.entrySet()) {
+            incrementalTracker.putFreshnessToken(entry.getKey(), entry.getValue());
+          }
+          LOGGER.info("Pipeline '{}': persisted {} per-period freshness tokens after clean commit",
+              pipelineName, pendingUnitFreshnessTokens.size());
+        }
       }
       // Per-period markers: mark each period whose full combo set is now processed,
       // even if OTHER periods in this table failed — markCompletedPeriods self-guards
@@ -1662,6 +1703,35 @@ public class EtlPipeline {
     // For null backfill_period the FetchUnit holds the raw combo — enrichment is a no-op.
     Map<String, String> variables = fetchUnit.getFetchVariables();
 
+    // Per-period freshness gate: probe this unit's templated source and skip the fetch+write when
+    // it is unchanged since the last clean commit. Returning 0 leaves the unit's existing Iceberg
+    // partition untouched (replacePartitions only rewrites the partitions we actually fetch), so
+    // unchanged periods are preserved without re-download or re-materialization. Only fires when a
+    // previous token exists (a prior clean run committed this unit's data) and the source is
+    // unchanged; otherwise the new token is captured for persistence after a clean commit.
+    if (perUnitFreshnessEnabled && dataSource instanceof HttpSource) {
+      FreshnessConfig freshnessConfig = config.getFreshness();
+      String unitKey = pipelineName + "::" + freshnessUnitKey(variables);
+      try {
+        HttpSource.ProbeResult probeResult =
+            ((HttpSource) dataSource).probe(freshnessConfig, variables);
+        String currentToken = FreshnessCheck.token(
+            freshnessConfig, probeResult.getHeaders(), probeResult.getBody(), null);
+        String previousToken = incrementalTracker.getFreshnessToken(unitKey);
+        if (previousToken != null && !FreshnessCheck.changed(previousToken, currentToken)) {
+          LOGGER.info("Pipeline '{}': per-period freshness UNCHANGED for unit {} (token={}) — "
+              + "skipping fetch and write", pipelineName, variables, currentToken);
+          return 0;
+        }
+        if (currentToken != null) {
+          pendingUnitFreshnessTokens.put(unitKey, currentToken);
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Pipeline '{}': per-period freshness probe failed for unit {} ({}), "
+            + "proceeding with full fetch", pipelineName, variables, e.getMessage());
+      }
+    }
+
     // Document sources use dataWriter directly — serialize writes
     if (EtlPipelineConfig.SOURCE_TYPE_DOCUMENT.equals(config.getSourceType())) {
       LOGGER.info("Document source - using custom DataWriter for processing");
@@ -1857,6 +1927,31 @@ public class EtlPipeline {
    * @param pipelineName pipeline name
    * @param rowCount     row count to record (shared equally across combos in the unit)
    */
+  /**
+   * Builds a deterministic per-unit freshness key from a fetch unit's substitution variables.
+   * The variables (the templated-URL inputs: year, state_fips, ...) fully determine the unit's
+   * source, so a sorted {@code key=value} join is a stable identity for the unit's freshness
+   * token across runs.
+   *
+   * @param variables the fetch unit's substitution variables
+   * @return a stable string identity for the unit
+   */
+  private static String freshnessUnitKey(Map<String, String> variables) {
+    if (variables == null || variables.isEmpty()) {
+      return "_empty";
+    }
+    List<String> keys = new ArrayList<String>(variables.keySet());
+    Collections.sort(keys);
+    StringBuilder sb = new StringBuilder();
+    for (String key : keys) {
+      if (sb.length() > 0) {
+        sb.append('&');
+      }
+      sb.append(key).append('=').append(variables.get(key));
+    }
+    return sb.toString();
+  }
+
   private void markCombosProcessed(FetchUnit fetchUnit, EtlPipelineConfig config,
       String pipelineName, long rowCount) {
     String backfillPeriod = config.getBackfillPeriod();

--- a/file/src/main/java/org/apache/calcite/adapter/file/partition/S3HivePipelineTracker.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/partition/S3HivePipelineTracker.java
@@ -911,6 +911,16 @@ public class S3HivePipelineTracker implements PipelineTracker, AutoCloseable {
     String compactedPath = bucketPath + "/year=" + year
         + "/_compacted/" + UUID.randomUUID().toString() + ".parquet";
 
+    // Capture the pre-existing compacted files BEFORE writing the new one. Each compacted file is
+    // cumulative (written from the full stageCache, which already merged the prior compacted files
+    // plus stragglers), so the new file is a strict superset of these — they are safe to delete
+    // after the new file commits. Without this, _compacted/ accumulates one near-full copy per
+    // compaction, so the fast-path read scans N copies of the same rows (the dominant cost of the
+    // tracker preload). Write-before-delete keeps it crash-safe; a fresh UUID means this list never
+    // contains the file we are about to write.
+    List<String> staleCompacted =
+        listTrackerFilesIncludeCompacted("year=" + year + "/_compacted/");
+
     // Write directly from stageCache to DuckDB temp table, avoiding
     // an intermediate ArrayList that duplicates all the data in memory.
     String tableName = "_compact_" + year.replace("-", "_");
@@ -975,9 +985,15 @@ public class S3HivePipelineTracker implements PipelineTracker, AutoCloseable {
         stmt.execute("DROP TABLE " + tableName);
       }
 
+      // New compacted file is durable — delete the stale cumulative copies it supersedes so the
+      // next read scans a single file instead of an ever-growing set.
+      if (staleCompacted != null && !staleCompacted.isEmpty()) {
+        deleteSpecificFiles(staleCompacted, year);
+      }
+
       long elapsed = System.currentTimeMillis() - start;
-      LOGGER.info("Compacted tracker year={}: {} rows written to S3 in {}ms",
-          year, rowCount, elapsed);
+      LOGGER.info("Compacted tracker year={}: {} rows written to S3 in {}ms ({} stale copies removed)",
+          year, rowCount, elapsed, staleCompacted == null ? 0 : staleCompacted.size());
     } catch (SQLException e) {
       LOGGER.warn("Failed to compact tracker year={}: {}", year, e.getMessage());
       try (Statement stmt = getConnection().createStatement()) {

--- a/file/src/test/java/org/apache/calcite/adapter/file/etl/FreshnessSkipGateTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/etl/FreshnessSkipGateTest.java
@@ -71,6 +71,16 @@ class FreshnessSkipGateTest {
       }
     }
 
+    /** Test accessor: snapshot of all currently-stored token keys. */
+    Set<String> tokenKeys() {
+      return new HashSet<String>(freshnessTokens.keySet());
+    }
+
+    /** Test accessor: remove a single token (used to isolate the per-unit gate). */
+    void removeToken(String key) {
+      freshnessTokens.remove(key);
+    }
+
     // --- Everything else is NOOP ---
 
     @Override public boolean isProcessed(String alternateName, String sourceTable,
@@ -183,6 +193,37 @@ class FreshnessSkipGateTest {
         .name("freshness_test_pipeline")
         .source(HttpSourceConfig.builder()
             .url("https://example.invalid/api")
+            .build())
+        .dimensions(dims)
+        .materialize(MaterializeConfig.builder()
+            .format(MaterializeConfig.Format.PARQUET)
+            .output(MaterializeOutputConfig.builder()
+                .location(tempDir.toString())
+                .build())
+            .build());
+    if (freshness != null) {
+      b.freshness(freshness);
+    }
+    return b.build();
+  }
+
+  /**
+   * Builds a config with a YEAR_RANGE period dimension (so {@code hasPeriodDimension} is true and
+   * the per-unit freshness gate is active) spanning {@code [startYear, endYear]}.
+   */
+  private EtlPipelineConfig buildPeriodConfig(FreshnessConfig freshness, int startYear, int endYear) {
+    Map<String, DimensionConfig> dims = new LinkedHashMap<String, DimensionConfig>();
+    dims.put("year", DimensionConfig.builder()
+        .name("year")
+        .type(DimensionType.YEAR_RANGE)
+        .start(startYear)
+        .end(endYear)
+        .build());
+
+    EtlPipelineConfig.Builder b = EtlPipelineConfig.builder()
+        .name("freshness_test_pipeline")
+        .source(HttpSourceConfig.builder()
+            .url("https://example.invalid/api/{year}")
             .build())
         .dimensions(dims)
         .materialize(MaterializeConfig.builder()
@@ -410,6 +451,76 @@ class FreshnessSkipGateTest {
     // New token must be persisted after the run
     assertEquals("etag-new", tracker.getFreshnessToken("freshness_test_pipeline"),
         "New token must be persisted after a successful run");
+  }
+
+  /**
+   * Per-period freshness gate (the "freshness OR period-completion OR both" composition).
+   *
+   * <p>The pipeline-level gate probes a single non-templated URL with an empty variable map, so it
+   * is a no-op for period tables whose source URL is templated. The per-unit gate in
+   * processSingleBatch probes each fetch unit's substituted URL and skips that unit when unchanged.
+   *
+   * <p>This test isolates the per-unit gate from the pipeline-level gate: it runs a two-year
+   * pipeline once to seed per-unit tokens, then REMOVES the pipeline-level token (so the
+   * pipeline-level gate proceeds, prev=null) while keeping the per-unit tokens, and asserts the
+   * second run fetches nothing — proving the skip came from the per-unit gate, not the
+   * pipeline-level one.
+   */
+  @Test void testPerPeriodFreshnessSkipsUnchangedUnits() throws IOException {
+    StorageProvider sp = new LocalFileStorageProvider();
+    MemoryFreshnessTracker tracker = new MemoryFreshnessTracker();
+
+    Map<String, String> probeHeaders = new HashMap<String, String>();
+    probeHeaders.put("ETag", "etag-stable");
+    HttpSource.ProbeResult probeResult = new HttpSource.ProbeResult(probeHeaders, null);
+
+    FreshnessConfig freshnessConfig = FreshnessConfig.fromMap(
+        Collections.<String, Object>singletonMap("type", "etag"));
+
+    Map<String, Object> row = new HashMap<String, Object>();
+    row.put("id", 1);
+    CountingDataProvider provider = new CountingDataProvider(Collections.singletonList(row));
+    CountingDataWriter writer = new CountingDataWriter();
+
+    StubHttpSource stubSource = new StubHttpSource(
+        HttpSourceConfig.builder().url("https://example.invalid/api/{year}").build(),
+        probeResult);
+
+    // Two periods → two fetch units.
+    EtlPipelineConfig config = buildPeriodConfig(freshnessConfig, 2023, 2024);
+
+    // --- First run: no tokens. Both periods fetch; per-unit tokens get persisted. ---
+    StubProbePipeline run1 = new StubProbePipeline(
+        config, sp, tempDir.toString(), tracker, provider, writer, stubSource);
+    run1.execute();
+    assertEquals(2, provider.fetchCount.get(),
+        "First run must fetch both periods (no tokens yet)");
+
+    Set<String> keys = tracker.tokenKeys();
+    List<String> perUnitKeys = new ArrayList<String>();
+    for (String k : keys) {
+      if (k.contains("::")) {
+        perUnitKeys.add(k);
+      }
+    }
+    assertEquals(2, perUnitKeys.size(),
+        "First run must persist a per-unit freshness token for each period (got " + keys + ")");
+
+    // --- Isolate the per-unit gate: drop the pipeline-level token, keep per-unit tokens. ---
+    tracker.removeToken(config.getName());
+    assertNull(tracker.getFreshnessToken(config.getName()),
+        "Pipeline-level token removed so the pipeline-level gate cannot be the cause of the skip");
+
+    // --- Second run: per-unit tokens unchanged → every unit skips via the per-unit gate. ---
+    provider.fetchCount.set(0);
+    writer.writeCount.set(0);
+    StubProbePipeline run2 = new StubProbePipeline(
+        config, sp, tempDir.toString(), tracker, provider, writer, stubSource);
+    run2.execute();
+    assertEquals(0, provider.fetchCount.get(),
+        "Second run must skip every period via the per-unit freshness gate (no fetch)");
+    assertEquals(0, writer.writeCount.get(),
+        "Second run must not write — every period skipped");
   }
 
   /**

--- a/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/StooqBulkProxy.java
+++ b/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/StooqBulkProxy.java
@@ -298,6 +298,42 @@ public class StooqBulkProxy {
     // Write to a staging sibling of the table location so the file-passthrough materializer can
     // move the parquet into Iceberg without a recursive walk hitting the table's own metadata.
     String stagingDir = stockPricesDir + "__staging";
+
+    // Freshness gate: the bulk zip is the same object every run unless a newer snapshot is staged.
+    // When its S3 size is unchanged since the last successful ingest AND the stock_prices table
+    // still holds data, skip the expensive DuckDB COPY (the ~23M-row extract+transform) and reuse
+    // the recorded max trading date. The data-existence check defeats the dq-rebuild skip-forever
+    // trap: a rebuild that clears the table directory forces a full re-ingest even if the marker
+    // survives. The marker is a sibling of the table location: "<remoteSize>|<maxDate>".
+    String markerPath = stockPricesDir + "__bulk.marker";
+    long remoteSize = -1L;
+    try {
+      remoteSize = storageProvider.getMetadata(bulkZipS3Path).getSize();
+    } catch (IOException e) {
+      LOGGER.warn("Could not read S3 metadata for {} to gate bulk ingest; proceeding with full "
+          + "ingest: {}", bulkZipS3Path, e.getMessage());
+    }
+    if (remoteSize > 0L) {
+      String marker = readMarker(markerPath);
+      if (marker != null) {
+        int sep = marker.indexOf('|');
+        if (sep > 0) {
+          long markedSize = -1L;
+          try {
+            markedSize = Long.parseLong(marker.substring(0, sep).trim());
+          } catch (NumberFormatException nfe) {
+            markedSize = -1L;  // unreadable marker → fall through to full ingest
+          }
+          String markedMaxDate = marker.substring(sep + 1);
+          if (markedSize == remoteSize && stockPricesHasData(stockPricesDir)) {
+            LOGGER.info("Bulk zip unchanged ({} bytes) and stock_prices already materialized — "
+                + "skipping bulk ingest; reusing max date {}", remoteSize, markedMaxDate);
+            return markedMaxDate;
+          }
+        }
+      }
+    }
+
     ensureLocalZip();
 
     // zipfs glob is unreliable across DuckDB builds; extract to local disk and read_csv real files.
@@ -363,7 +399,65 @@ public class StooqBulkProxy {
       deleteDir(extractDir);
     }
     LOGGER.info("Bulk stock-price ingest complete, max date = {}", maxDate);
+    // Record the ingested zip size + max date so an unchanged next run can skip the COPY.
+    if (remoteSize > 0L) {
+      writeMarker(markerPath, remoteSize + "|" + maxDate);
+    }
     return maxDate;
+  }
+
+  /** Reads the bulk-ingest marker, or null if absent/unreadable. */
+  private String readMarker(String markerPath) {
+    try {
+      if (!storageProvider.exists(markerPath)) {
+        return null;
+      }
+      try (InputStream in = storageProvider.openInputStream(markerPath)) {
+        byte[] bytes = readAllBytes(in);
+        return new String(bytes, StandardCharsets.UTF_8).trim();
+      }
+    } catch (IOException e) {
+      LOGGER.warn("Could not read bulk-ingest marker {}: {}", markerPath, e.getMessage());
+      return null;
+    }
+  }
+
+  /** Writes the bulk-ingest marker. */
+  private void writeMarker(String markerPath, String value) {
+    try {
+      storageProvider.writeFile(markerPath, value.getBytes(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      LOGGER.warn("Could not write bulk-ingest marker {}: {}", markerPath, e.getMessage());
+    }
+  }
+
+  /** True when the stock_prices table directory exists and contains at least one parquet file. */
+  private boolean stockPricesHasData(String stockPricesDir) {
+    try {
+      if (!storageProvider.isDirectory(stockPricesDir)) {
+        return false;
+      }
+      for (StorageProvider.FileEntry entry : storageProvider.listFiles(stockPricesDir, true)) {
+        if (!entry.isDirectory() && entry.getPath().endsWith(".parquet")) {
+          return true;
+        }
+      }
+    } catch (IOException e) {
+      LOGGER.warn("Could not list {} to confirm stock_prices data; treating as empty: {}",
+          stockPricesDir, e.getMessage());
+    }
+    return false;
+  }
+
+  /** Reads an input stream fully into a byte array (Java 8; no InputStream.readAllBytes). */
+  private static byte[] readAllBytes(InputStream in) throws IOException {
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    byte[] buf = new byte[8192];
+    int n;
+    while ((n = in.read(buf)) != -1) {
+      out.write(buf, 0, n);
+    }
+    return out.toByteArray();
   }
 
   /** Extracts all entries of the local bulk zip under {@code targetDir}. */


### PR DESCRIPTION
Three validated DQ re-run performance fixes (see [[dq-skip-mechanisms]]).

## #1 — Compose freshness with per-period completion (fresh OR period OR both)
Per-unit freshness gate in `EtlPipeline.processSingleBatch` probes each fetch unit's substituted URL and skips fetch+write when unchanged. Closes the gap where the pipeline-level gate (single non-templated URL, empty var map) was a no-op for templated period tables. Additive; cold-start seeds the token, only the skip is gated on committed data.
**Validated:** `FreshnessSkipGateTest` 11/11, incl. `testPerPeriodFreshnessSkipsUnchangedUnits` (isolates the per-unit gate → 2nd run fetches 0).

## #2 — Gate sec_prices bulk ingest on zip freshness
Skip the ~23M-row DuckDB COPY when the bulk zip's S3 size is unchanged AND stock_prices still holds data (existence check defeats the dq-rebuild skip-forever trap). Marker: `stock_prices__bulk.marker = <size>|<maxDate>`.
**Validated:** pass 2 logged "skipping bulk ingest"; stock_prices = 23,100,354 rows intact; sec_prices DQ PASS (2/2, 0 fails).

## #3 — Consolidate compacted tracker files
`compactFromCache` now deletes the cumulative copies it supersedes (write-before-delete, superset guarantee), instead of accumulating one per call — the dominant cost of the SEC tracker preload (49s reading 5 stacked copies of one year).
**Validated:** `_compacted` per year 3–5 → 1 across all years.

🤖 Generated with [Claude Code](https://claude.com/claude-code)