### PR TITLE
Trino connectors (calcite, sharepoint, splunk) + JDBC driver/adapter fixes

### DIFF
--- a/.github/workflows/trino-connectors.yml
+++ b/.github/workflows/trino-connectors.yml
@@ -1,0 +1,116 @@
+name: Trino Connectors
+
+# Builds the Trino connector plugin packages (a directory-of-jars archive each) and attaches them
+# to a GitHub Release. Trino plugins are not Maven artifacts: you unzip the archive into the Trino
+# server's plugin/ directory. The connectors target the Trino SPI pinned by `trino.version` in
+# gradle.properties (built with a Java 25 toolchain; Gradle itself runs on Java 21).
+
+on:
+  push:
+    tags:
+      - 'trino-v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        default: '1.0.0'
+
+jobs:
+  build:
+    name: Build Trino connector packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Java 25 for the connector toolchain (Trino SPI) plus Java 21 to run Gradle 8.7.
+      # Last-listed version becomes the default JAVA_HOME (21), which runs Gradle.
+      - name: Set up JDKs
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: |
+            25
+            21
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts', '**/*.gradle', 'gradle.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Build plugin packages
+        run: |
+          ./gradlew \
+            :trino-calcite:trinoPlugin \
+            :trino-sharepoint:trinoPlugin \
+            :trino-splunk:trinoPlugin \
+            -Porg.gradle.java.installations.paths="${JAVA_HOME_25_X64},${JAVA_HOME_21_X64}" \
+            --no-daemon
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#trino-v}"
+          else
+            VERSION="${{ github.event.inputs.version }}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Packaging version: $VERSION"
+
+      - name: Collect plugin archives
+        run: |
+          mkdir -p release-assets
+          for module in trino-calcite trino-sharepoint trino-splunk; do
+            src=$(ls ${module}/build/distributions/${module}-plugin-*.zip 2>/dev/null | head -1)
+            if [ -z "$src" ]; then
+              echo "ERROR: no plugin archive found for $module"
+              exit 1
+            fi
+            cp "$src" "release-assets/${module}-plugin-${{ steps.version.outputs.version }}.zip"
+            echo "$module: $(du -sh release-assets/${module}-plugin-${{ steps.version.outputs.version }}.zip | cut -f1)"
+          done
+          ls -lh release-assets/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: trino-connector-packages
+          path: release-assets/
+          retention-days: 30
+
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Trino Connectors ${{ github.ref_name }}
+          body: |
+            ## Trino Connectors ${{ steps.version.outputs.version }}
+
+            Trino connector plugin packages built against the Trino SPI version pinned in
+            `gradle.properties`. Each archive is a Trino **plugin directory** — unzip it into your
+            Trino server's `plugin/` directory and restart.
+
+            | Package | Connector name | Backing driver |
+            |---------|----------------|----------------|
+            | `trino-calcite-plugin-*.zip` | `calcite` | generic Calcite model (`jdbc:calcite:`) |
+            | `trino-sharepoint-plugin-*.zip` | `sharepoint` | SharePoint Lists (`jdbc:sharepoint:`) |
+            | `trino-splunk-plugin-*.zip` | `splunk` | Splunk (`jdbc:splunk:`) |
+
+            ### Install
+
+            ```bash
+            unzip trino-sharepoint-plugin-*.zip -d "$TRINO_HOME/plugin/"
+            # then add etc/catalog/<name>.properties with connector.name=<connector name>
+            ```
+          files: release-assets/*.zip
+          draft: false
+          prerelease: false

--- a/cloud-ops/src/main/java/org/apache/calcite/adapter/ops/CloudOpsDriver.java
+++ b/cloud-ops/src/main/java/org/apache/calcite/adapter/ops/CloudOpsDriver.java
@@ -50,7 +50,11 @@ public class CloudOpsDriver extends org.apache.calcite.jdbc.Driver {
         Properties params = new Properties(info);
         parseParams(remainder, params);
         String model = buildModel(params);
-        return super.connect("jdbc:calcite:model=inline:" + model, params);
+        // Delegate to a plain Calcite driver. We cannot use super.connect here: the inherited
+        // UnregisteredDriver.connect gates on acceptsURL(), which uses our overridden prefix
+        // ("jdbc:cloudops:") and would reject the "jdbc:calcite:" URL, returning null.
+        return new org.apache.calcite.jdbc.Driver()
+            .connect("jdbc:calcite:model=inline:" + model, params);
     }
 
     private void parseParams(String paramStr, Properties props) {

--- a/file/src/main/java/org/apache/calcite/adapter/file/AperioDriver.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/AperioDriver.java
@@ -56,8 +56,12 @@ public class AperioDriver extends org.apache.calcite.jdbc.Driver {
 
         String remainder = url.substring(getConnectStringPrefix().length());
 
+        // Delegate to a plain Calcite driver throughout: super.connect would route through the
+        // inherited UnregisteredDriver.connect, whose acceptsURL() uses our overridden prefix
+        // ("jdbc:aperio:") and rejects the "jdbc:calcite:" URL, returning null.
         if (remainder.startsWith("model=")) {
-            return super.connect("jdbc:calcite:model=" + remainder.substring(6), info);
+            return new org.apache.calcite.jdbc.Driver()
+                .connect("jdbc:calcite:model=" + remainder.substring(6), info);
         }
 
         String path;
@@ -72,7 +76,8 @@ public class AperioDriver extends org.apache.calcite.jdbc.Driver {
         }
 
         String model = buildModel(path, params);
-        return super.connect("jdbc:calcite:model=inline:" + model, params);
+        return new org.apache.calcite.jdbc.Driver()
+            .connect("jdbc:calcite:model=inline:" + model, params);
     }
 
     private void parseQueryParams(String queryString, Properties props) {

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
@@ -2327,15 +2327,15 @@ public class EtlPipeline {
       return unprocessed;
     }
 
-    // Verify existing partitions are not stale - they should be a subset of expected combinations
-    // Convert combinations to a set for efficient lookup
-    Set<Map<String, String>> expectedSet =
-        new HashSet<Map<String, String>>(combinations);
-    Set<Map<String, String>> stalePartitions =
+    // Project each existing Iceberg partition down to just the partition columns. Match is done
+    // on partition-column PROJECTIONS of BOTH sides: a combination may carry extra non-partition
+    // dimensions (e.g. a derived 'effective_year' used only in the URL template) that are NOT
+    // partition columns, so comparing a full combo against a partition-only map would never match
+    // — flagging every existing partition "stale" and rebuilding 0, the bug that made acs* and any
+    // table with a derived dimension reprocess in full on every resume.
+    Set<Map<String, String>> existingPartitionKeys =
         new HashSet<Map<String, String>>();
-
     for (Map<String, String> existing : existingPartitions) {
-      // Extract only the partition columns we care about for comparison
       Map<String, String> partitionOnly = new LinkedHashMap<String, String>();
       for (String col : partitionColumns) {
         String val = existing.get(col);
@@ -2343,24 +2343,41 @@ public class EtlPipeline {
           partitionOnly.put(col, val);
         }
       }
-      if (!expectedSet.contains(partitionOnly)) {
-        stalePartitions.add(partitionOnly);
+      existingPartitionKeys.add(partitionOnly);
+    }
+
+    // For each combination, project it to the partition columns. If that projection exists in the
+    // Iceberg table, the combination is already materialized — record the FULL combo for marking
+    // (the per-combo tracker keys on the full combo incl. non-partition dims, so we must mark the
+    // full combo, not the projection, or the re-filter below would still treat it as unprocessed).
+    Set<Map<String, String>> matchedExisting =
+        new HashSet<Map<String, String>>();
+    List<Map<String, String>> rebuildableCombos =
+        new ArrayList<Map<String, String>>();
+    Set<Integer> rebuiltIndices = new HashSet<Integer>();
+    for (int i = 0; i < combinations.size(); i++) {
+      Map<String, String> combo = combinations.get(i);
+      Map<String, String> comboKey = new LinkedHashMap<String, String>();
+      for (String col : partitionColumns) {
+        String val = combo.get(col);
+        if (val != null) {
+          comboKey.put(col, val);
+        }
+      }
+      if (existingPartitionKeys.contains(comboKey)) {
+        rebuildableCombos.add(combo);
+        rebuiltIndices.add(i);
+        matchedExisting.add(comboKey);
       }
     }
 
-    // Find partitions that ARE in expected set (can be rebuilt)
-    Set<Map<String, String>> rebuildable =
+    // Existing partitions matching NO current combination are genuinely stale (e.g. a year no
+    // longer in the configured range) — left alone, not rebuilt.
+    Set<Map<String, String>> stalePartitions =
         new HashSet<Map<String, String>>();
-    for (Map<String, String> existing : existingPartitions) {
-      Map<String, String> partitionOnly = new LinkedHashMap<String, String>();
-      for (String col : partitionColumns) {
-        String val = existing.get(col);
-        if (val != null) {
-          partitionOnly.put(col, val);
-        }
-      }
-      if (expectedSet.contains(partitionOnly)) {
-        rebuildable.add(partitionOnly);
+    for (Map<String, String> key : existingPartitionKeys) {
+      if (!matchedExisting.contains(key)) {
+        stalePartitions.add(key);
       }
     }
 
@@ -2368,10 +2385,10 @@ public class EtlPipeline {
       LOGGER.info("Found {} stale partitions in Iceberg table '{}' not in current dimensions "
           + "(Example: {}). These will be ignored - only {} current partitions will be rebuilt.",
           stalePartitions.size(), targetTableId,
-          stalePartitions.iterator().next(), rebuildable.size());
+          stalePartitions.iterator().next(), matchedExisting.size());
     }
 
-    if (rebuildable.isEmpty()) {
+    if (rebuildableCombos.isEmpty()) {
       LOGGER.debug("No rebuildable partitions found for table '{}', skipping cache rebuild",
           targetTableId);
       return unprocessed;
@@ -2379,21 +2396,28 @@ public class EtlPipeline {
 
     // Rebuild cache from existing partitions that match current dimensions
     LOGGER.info("Self-healing: Rebuilding cache from {} existing Iceberg partitions for table '{}'",
-        rebuildable.size(), targetTableId);
+        matchedExisting.size(), targetTableId);
 
     int rebuilt = 0;
-    for (Map<String, String> partition : rebuildable) {
-      // Mark with -1 (unknown row count but has data) to indicate non-empty
+    for (Map<String, String> combo : rebuildableCombos) {
+      // Mark the FULL combo with -1 (unknown row count but has data) to indicate non-empty
       incrementalTracker.markProcessedWithRowCount(
-          pipelineName, pipelineName, partition, null, -1);
+          pipelineName, pipelineName, combo, null, -1);
       rebuilt++;
     }
 
     LOGGER.info("Self-healing complete: Rebuilt cache with {} partition entries from Iceberg metadata",
         rebuilt);
 
-    // Re-filter after rebuild so Phase 2 can reuse the result
-    return incrementalTracker.filterUnprocessed(pipelineName, pipelineName, combinations);
+    // Do NOT re-read the tracker here. filterUnprocessed caches a table's processed-key set on its
+    // FIRST call (the one above, when the tracker was still empty), and markProcessedWithRowCount
+    // buffers to pendingStates without updating that in-memory cache — so a re-filter would return
+    // the stale pre-mark result and reprocess everything anyway (the bug where self-heal matched
+    // partitions yet still logged "Processing N unprocessed batches"). Instead subtract the indices
+    // we just rebuilt from the initial unprocessed set. The buffered marks are persisted later by
+    // markCompletedPeriods (which flushes before its isProcessed reads) and by pipeline close.
+    unprocessed.removeAll(rebuiltIndices);
+    return unprocessed;
   }
 
   /**

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/HttpSource.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/HttpSource.java
@@ -1277,6 +1277,15 @@ public class HttpSource implements DataSource {
       fullUrl = buildUrlWithParams(baseUrl, params);
     }
 
+    // Circuit breaker: if this origin has returned >= threshold consecutive 503s, treat it as down
+    // and fast-skip (no request, no retries) until a success resets it. EtlPipeline catches
+    // SkippedBatchException and skips the batch gracefully.
+    java.util.concurrent.atomic.AtomicInteger open = CONSECUTIVE_503.get(baseUri(fullUrl));
+    if (open != null && open.get() >= CIRCUIT_503_THRESHOLD) {
+      throw new SkippedBatchException("Circuit open — origin returned >= " + CIRCUIT_503_THRESHOLD
+          + " consecutive 503s, fast-skipping: " + baseUri(fullUrl));
+    }
+
     HttpSourceConfig.RateLimitConfig rateLimit = config.getRateLimit();
     int retries = 0;
     IOException lastException = null;
@@ -1292,7 +1301,14 @@ public class HttpSource implements DataSource {
         if (shouldRetry(e, rateLimit)) {
           retries++;
           if (retries <= rateLimit.getMaxRetries()) {
-            long backoff = rateLimit.getRetryBackoffMs() * (1L << (retries - 1));
+            long backoff;
+            if (e instanceof RetryableHttpException
+                && ((RetryableHttpException) e).retryAfterMs >= 0L) {
+              // Server told us exactly how long to wait (503/429 Retry-After) — honor it (capped).
+              backoff = ((RetryableHttpException) e).retryAfterMs;
+            } else {
+              backoff = rateLimit.getRetryBackoffMs() * (1L << (retries - 1));
+            }
             LOGGER.warn("Request failed, retrying in {}ms (attempt {}/{}): {}",
                 backoff, retries, rateLimit.getMaxRetries(), e.getMessage());
             try {
@@ -1309,6 +1325,53 @@ public class HttpSource implements DataSource {
     }
 
     throw lastException != null ? lastException : new IOException("Request failed after retries");
+  }
+
+  // ── 503 circuit breaker + Retry-After ──────────────────────────────────────────────────────
+  /** Consecutive HTTP-503 responses per base URI (scheme+host+path, no query). When a base URI
+   *  reaches {@link #CIRCUIT_503_THRESHOLD} its origin is treated as down: further requests to it
+   *  fast-skip (the batch is skipped) instead of retrying, until any 2xx resets the count. A 503
+   *  means the request never reached the origin's app layer, so retrying it endlessly only wastes
+   *  the worker — once it's clearly persistent we stop calling that URI. */
+  private static final java.util.concurrent.ConcurrentMap<String, java.util.concurrent.atomic.AtomicInteger>
+      CONSECUTIVE_503 =
+          new java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicInteger>();
+  private static final int CIRCUIT_503_THRESHOLD = 5;
+  /** Cap on how long we honor a server-provided Retry-After — a maintenance window can be hours,
+   *  and we must not block a worker indefinitely. */
+  private static final long RETRY_AFTER_CAP_MS = 300_000L;
+
+  /** A retryable HTTP error carrying the server's Retry-After delay in ms (-1 if not provided). */
+  private static final class RetryableHttpException extends IOException {
+    private final long retryAfterMs;
+    RetryableHttpException(String message, long retryAfterMs) {
+      super(message);
+      this.retryAfterMs = retryAfterMs;
+    }
+  }
+
+  /** The circuit-breaker key for a request: the URL with the query string stripped. */
+  private static String baseUri(String fullUrl) {
+    int q = fullUrl.indexOf('?');
+    return q >= 0 ? fullUrl.substring(0, q) : fullUrl;
+  }
+
+  /** Parses a Retry-After header (delta-seconds or HTTP-date) to ms, capped; -1 if absent. */
+  private static long parseRetryAfter(HttpURLConnection conn) {
+    String ra = conn.getHeaderField("Retry-After");
+    if (ra == null || ra.trim().isEmpty()) {
+      return -1L;
+    }
+    try {
+      return Math.min(RETRY_AFTER_CAP_MS, Long.parseLong(ra.trim()) * 1000L);
+    } catch (NumberFormatException notSeconds) {
+      long when = conn.getHeaderFieldDate("Retry-After", -1L);
+      if (when > 0L) {
+        long delta = when - System.currentTimeMillis();
+        return delta <= 0L ? 0L : Math.min(RETRY_AFTER_CAP_MS, delta);
+      }
+      return -1L;
+    }
   }
 
   /**
@@ -1443,6 +1506,11 @@ public class HttpSource implements DataSource {
       LOGGER.debug("HTTP {} {} -> {}", config.getMethod(), urlString, responseCode);
 
       if (responseCode >= 200 && responseCode < 300) {
+        // Success — clear the circuit-breaker 503 count for this origin.
+        java.util.concurrent.atomic.AtomicInteger ok = CONSECUTIVE_503.get(baseUri(urlString));
+        if (ok != null) {
+          ok.set(0);
+        }
         // Check if we need to extract from ZIP
         String extractPattern = config.getExtractPattern();
         if (extractPattern != null && !extractPattern.isEmpty()) {
@@ -1498,6 +1566,22 @@ public class HttpSource implements DataSource {
         if (shouldSkip(responseCode, config.getRateLimit())) {
           LOGGER.debug("HTTP {} from {} — skipping batch (skipOn match)", responseCode, urlString);
           throw new SkippedBatchException("HTTP " + responseCode + " (skipped): " + urlString);
+        }
+        // 503/429: capture any Retry-After so the retry honors it. Count consecutive 503s per base
+        // URI so a persistently-down origin trips the circuit breaker (subsequent calls fast-skip).
+        if (responseCode == 503 || responseCode == 429) {
+          long retryAfterMs = parseRetryAfter(conn);
+          if (responseCode == 503) {
+            int n = CONSECUTIVE_503
+                .computeIfAbsent(baseUri(urlString),
+                    k -> new java.util.concurrent.atomic.AtomicInteger())
+                .incrementAndGet();
+            if (n == CIRCUIT_503_THRESHOLD) {
+              LOGGER.warn("Circuit OPEN: {} consecutive 503s for {} — origin down, "
+                  + "fast-skipping further calls until a success", n, baseUri(urlString));
+            }
+          }
+          throw new RetryableHttpException("HTTP " + responseCode + ": " + errorBody, retryAfterMs);
         }
         throw new IOException("HTTP " + responseCode + ": " + errorBody);
       }

--- a/govdata/scripts/parallel/worker-dq-run.sh
+++ b/govdata/scripts/parallel/worker-dq-run.sh
@@ -190,7 +190,7 @@ _file_script_error_issue() {
     --limit 200 \
     --json number,title \
     --jq ".[] | select(.title | startswith(\"[DQ] ${SCHEMA}:\")) | .number" \
-    2>&1 | head -1)
+    2>&1 | head -1 || true)
   if [ -n "$open_issue" ] && [[ "$open_issue" =~ ^[0-9]+$ ]]; then
     gh issue comment "$open_issue" \
       --repo kenstott/calcite \
@@ -687,6 +687,9 @@ if _gh_available; then
   gh label create "dq-fail" --color "#d93f0b" --description "DQ hard failure" --repo kenstott/calcite 2>/dev/null || true
 
   # Find existing open DQ issue for this schema
+  # `… | head -1` can return non-zero under `set -euo pipefail` (gh gets SIGPIPE when head closes
+  # the pipe early, or a transient gh API/rate-limit blip) — which under set -e would abort the
+  # script AFTER a clean DQ pass and trip the error-issue trap. Guard so a passing run stays passing.
   OPEN_ISSUE=$(gh issue list \
     --repo kenstott/calcite \
     --state open \
@@ -694,7 +697,7 @@ if _gh_available; then
     --limit 200 \
     --json number,title \
     --jq ".[] | select(.title | startswith(\"[DQ] ${SCHEMA}:\")) | .number" \
-    2>/dev/null | head -1)
+    2>/dev/null | head -1 || true)
 
   if [ "$VERDICT" = "PASS" ]; then
     if [ -n "$OPEN_ISSUE" ]; then

--- a/govdata/src/main/resources/cyber/cyber-threat-schema.yaml
+++ b/govdata/src/main/resources/cyber/cyber-threat-schema.yaml
@@ -14,6 +14,13 @@
 schemaName: "${CYBER_THREAT_SCHEMA_NAME:cyber_threat}"
 materializeDirectory: "${GOVDATA_PARQUET_DIR}"
 
+# OTX incremental window (days). When set to a positive integer, OtxResponseTransformer
+# appends modified_since=now-N days to the subscribed-pulses URL and walks only the bounded,
+# filtered chain (production daily/incremental). Empty default = full load of all subscribed
+# pulses (initial/historical). Read via ModelOperand path cyber_threat.otxDeltaDays; DQ-sample
+# mode (GOVDATA_DQ) ignores it and always full-loads (capped by dqRowLimit).
+otxDeltaDays: "${CYBER_OTX_DELTA_DAYS:}"
+
 comment: >
   Cyber threat intelligence, exploit data, IOC feeds, MITRE ATT&CK taxonomy,
   and standards/compliance mappings. Part of the govdata cyber sub-domain.

--- a/gradle.properties
+++ b/gradle.properties
@@ -122,6 +122,10 @@ hydromatic.tpcds.version=0.4
 immutables.version=2.8.8
 innodb-java-reader.version=1.0.10
 jackson.version=2.18.4.1
+# Trino connector subprojects (trino-calcite, trino-sharepoint). These modules build with
+# their own Java 25 toolchain (see their build.gradle.kts); a Trino plugin must match the
+# exact SPI version of the server it is deployed into.
+trino.version=481
 janino.version=3.1.12
 java-diff.version=1.1.2
 jcip-annotations.version=1.0-1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -94,7 +94,8 @@ include(
     "ubenchmark",
     "driver-base",
     "govdata",
-    "askamerica-engine"
+    "askamerica-engine",
+    "trino-calcite"
 )
 
 // See https://github.com/gradle/gradle/issues/1348#issuecomment-284758705 and

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,7 +96,8 @@ include(
     "govdata",
     "askamerica-engine",
     "trino-calcite",
-    "trino-sharepoint"
+    "trino-sharepoint",
+    "trino-splunk"
 )
 
 // See https://github.com/gradle/gradle/issues/1348#issuecomment-284758705 and

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,7 +95,8 @@ include(
     "driver-base",
     "govdata",
     "askamerica-engine",
-    "trino-calcite"
+    "trino-calcite",
+    "trino-sharepoint"
 )
 
 // See https://github.com/gradle/gradle/issues/1348#issuecomment-284758705 and

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/MicrosoftGraphListClient.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/MicrosoftGraphListClient.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Microsoft Graph API client for SharePoint Lists operations.
@@ -37,16 +38,56 @@ import java.util.Map;
 public class MicrosoftGraphListClient {
   private static final String GRAPH_API_BASE = "https://graph.microsoft.com/v1.0";
   private static final int MAX_BATCH_SIZE = 20; // Graph API batch limit
+  private static final long DEFAULT_CACHE_TTL_MILLIS = 300_000L; // 5 minutes
+
+  /**
+   * Process-wide cache of discovered lists (with their columns), keyed by site URL, shared across
+   * client instances. Without it, every new JDBC connection re-crawls the whole site (a GET /lists
+   * plus one column fetch per list) just to rebuild the schema — which is both slow and a Microsoft
+   * Graph throttling (HTTP 429) risk under engines like Trino that open a connection per query.
+   */
+  private static final Map<String, CachedLists> LIST_CACHE = new ConcurrentHashMap<>();
 
   private final String siteUrl;
   private final SharePointAuth authenticator;
   private final ObjectMapper objectMapper;
+  // -1 = never expires, 0 = caching disabled, > 0 = time-to-live in milliseconds.
+  private final long cacheTtlMillis;
   private String siteId;
 
   public MicrosoftGraphListClient(String siteUrl, SharePointAuth authenticator) {
+    this(siteUrl, authenticator, DEFAULT_CACHE_TTL_MILLIS);
+  }
+
+  public MicrosoftGraphListClient(String siteUrl, SharePointAuth authenticator,
+      long cacheTtlMillis) {
     this.siteUrl = siteUrl.endsWith("/") ? siteUrl.substring(0, siteUrl.length() - 1) : siteUrl;
     this.authenticator = authenticator;
     this.objectMapper = new ObjectMapper();
+    this.cacheTtlMillis = cacheTtlMillis;
+  }
+
+  /** Cached discovery result with an absolute expiry (or -1 for no expiry). */
+  private static final class CachedLists {
+    private final Map<String, SharePointListMetadata> lists;
+    private final long expiryMillis;
+
+    CachedLists(Map<String, SharePointListMetadata> lists, long expiryMillis) {
+      this.lists = lists;
+      this.expiryMillis = expiryMillis;
+    }
+
+    boolean isFresh() {
+      return expiryMillis < 0 || System.currentTimeMillis() < expiryMillis;
+    }
+  }
+
+  /**
+   * Drops this site's cached list metadata so the next discovery re-crawls. Call after a list is
+   * created or dropped so the change is visible immediately rather than after the TTL.
+   */
+  public void invalidateListCache() {
+    LIST_CACHE.remove(siteUrl);
   }
 
   /**
@@ -82,6 +123,13 @@ public class MicrosoftGraphListClient {
    */
   public Map<String, SharePointListMetadata> getAvailableLists()
       throws IOException, InterruptedException {
+    if (cacheTtlMillis != 0) {
+      CachedLists cached = LIST_CACHE.get(siteUrl);
+      if (cached != null && cached.isFresh()) {
+        return cached.lists;
+      }
+    }
+
     ensureInitialized();
 
     // First get the lists
@@ -107,9 +155,16 @@ public class MicrosoftGraphListClient {
           String displayName = list.get("displayName").asText();
           String entityTypeName = list.get("name").asText();
 
+          // Capture the list template (genericList, documentLibrary, events, tasks, ...) so the
+          // table can gate writes by list type.
+          String template = null;
+          if (list.has("list") && list.get("list").has("template")) {
+            template = list.get("list").get("template").asText();
+          }
+
           // Get columns separately
           List<SharePointColumn> columns = getListColumns(listId);
-          SharePointListMetadata metadata = new SharePointListMetadata(listId, displayName, entityTypeName, columns);
+          SharePointListMetadata metadata = new SharePointListMetadata(listId, displayName, entityTypeName, columns, template);
           // Use SQL-friendly name as the key
           lists.put(metadata.getListName(), metadata);
         }
@@ -117,6 +172,11 @@ public class MicrosoftGraphListClient {
 
       // Check for next page
       nextLink = response.has("@odata.nextLink") ? response.get("@odata.nextLink").asText() : null;
+    }
+
+    if (cacheTtlMillis != 0) {
+      long expiry = cacheTtlMillis < 0 ? -1 : System.currentTimeMillis() + cacheTtlMillis;
+      LIST_CACHE.put(siteUrl, new CachedLists(lists, expiry));
     }
 
     return lists;

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointDdlExecutor.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointDdlExecutor.java
@@ -54,12 +54,21 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
     try {
       // Build column definitions from the CREATE TABLE statement
       List<SharePointColumn> columns = new ArrayList<>();
+      // List type/template. Specify a non-generic list (calendar, tasks, ...) with a sentinel
+      // column:  CREATE TABLE x ("__template" VARCHAR DEFAULT 'calendar', ...). The sentinel is
+      // read for the template and not created as a field.
+      String template = "genericList";
 
       if (create.columnList != null) {
         for (SqlNode node : create.columnList) {
           if (node instanceof SqlColumnDeclaration) {
             SqlColumnDeclaration col = (SqlColumnDeclaration) node;
             String columnName = col.name.getSimple();
+
+            if ("__template".equalsIgnoreCase(columnName)) {
+              template = normalizeTemplate(extractDefaultString(col.expression));
+              continue;
+            }
 
             // For now, use a simple type mapping
             // In a full implementation, we'd derive the type from col.dataType
@@ -83,7 +92,7 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
       }
 
       // Create the SharePoint list
-      createSharePointList(spSchema, listName, columns);
+      createSharePointList(spSchema, listName, columns, template);
 
       // Refresh the schema to include the new list
       spSchema.refresh();
@@ -131,19 +140,71 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
   }
 
   private void createSharePointList(SharePointListSchema schema, String listName,
-      List<SharePointColumn> columns) throws IOException, InterruptedException {
+      List<SharePointColumn> columns, String template) throws IOException, InterruptedException {
 
     if (schema.useRestApi()) {
       // Use SharePoint REST API
-      createSharePointListRest(schema, listName, columns);
+      createSharePointListRest(schema, listName, columns, template);
     } else {
       // Use Microsoft Graph API
-      createSharePointListGraph(schema, listName, columns);
+      createSharePointListGraph(schema, listName, columns, template);
     }
   }
 
+  /**
+   * Normalizes a user-supplied template name to a Microsoft Graph list template. Accepts friendly
+   * aliases (calendar, task) and the Graph names directly; defaults to genericList.
+   */
+  private static String normalizeTemplate(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return "genericList";
+    }
+    switch (value.trim().toLowerCase(java.util.Locale.ROOT)) {
+    case "calendar":
+    case "events":
+      return "events";
+    case "task":
+    case "tasks":
+      return "tasks";
+    case "announcements":
+      return "announcements";
+    case "contacts":
+      return "contacts";
+    case "links":
+      return "links";
+    default:
+      return "genericList";
+    }
+  }
+
+  /** SharePoint REST BaseTemplate code for a Graph template name. */
+  private static int restBaseTemplate(String template) {
+    switch (template) {
+    case "events":
+      return 106;
+    case "tasks":
+      return 171;
+    case "announcements":
+      return 104;
+    case "contacts":
+      return 105;
+    case "links":
+      return 103;
+    default:
+      return 100; // genericList
+    }
+  }
+
+  /** Extracts the string value of a column DEFAULT expression (a char literal), or null. */
+  private static String extractDefaultString(SqlNode expression) {
+    if (expression instanceof org.apache.calcite.sql.SqlLiteral) {
+      return ((org.apache.calcite.sql.SqlLiteral) expression).toValue();
+    }
+    return null;
+  }
+
   private void createSharePointListGraph(SharePointListSchema schema, String listName,
-      List<SharePointColumn> columns) throws IOException, InterruptedException {
+      List<SharePointColumn> columns, String template) throws IOException, InterruptedException {
 
     MicrosoftGraphListClient client = schema.getClient();
 
@@ -152,9 +213,9 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
     requestBody.put("displayName", listName);
     requestBody.put("description", "Created by Apache Calcite SharePoint Adapter");
 
-    // Create list with basic template (Generic List = 100)
+    // Create list with the requested template (genericList, events, tasks, ...)
     ObjectNode list = MAPPER.createObjectNode();
-    list.put("template", "genericList");
+    list.put("template", template);
     requestBody.set("list", list);
 
     // Create the list first
@@ -171,7 +232,7 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
   }
 
   private void createSharePointListRest(SharePointListSchema schema, String listName,
-      List<SharePointColumn> columns) throws IOException, InterruptedException {
+      List<SharePointColumn> columns, String template) throws IOException, InterruptedException {
 
     SharePointRestListClient restClient = schema.getRestClient();
     String siteUrl = restClient.getSiteUrl();
@@ -183,7 +244,7 @@ public class SharePointDdlExecutor extends DdlExecutorImpl {
     requestBody.set("__metadata", metadata);
     requestBody.put("Title", listName);
     requestBody.put("Description", "Created by Apache Calcite SharePoint Adapter");
-    requestBody.put("BaseTemplate", 100); // Generic List template
+    requestBody.put("BaseTemplate", restBaseTemplate(template));
     requestBody.put("EnableAttachments", true);
 
     // Create the list using REST API

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListDriver.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListDriver.java
@@ -48,7 +48,11 @@ public class SharePointListDriver extends org.apache.calcite.jdbc.Driver {
         Properties params = new Properties(info);
         parseParams(remainder, params);
         String model = buildModel(params);
-        return super.connect("jdbc:calcite:model=inline:" + model, params);
+        // Delegate to a plain Calcite driver. We cannot use super.connect here: the inherited
+        // UnregisteredDriver.connect gates on acceptsURL(), which uses our overridden prefix
+        // ("jdbc:sharepoint:") and would reject the "jdbc:calcite:" URL, returning null.
+        return new org.apache.calcite.jdbc.Driver()
+            .connect("jdbc:calcite:model=inline:" + model, params);
     }
 
     private void parseParams(String paramStr, Properties props) {
@@ -80,8 +84,13 @@ public class SharePointListDriver extends org.apache.calcite.jdbc.Driver {
                 operand.put(key, props.getProperty(key));
             }
 
+            // Schema name is configurable via the "schema" (or "currentSchema") parameter,
+            // defaulting to "sharepoint".
+            String schemaName = props.getProperty("schema",
+                props.getProperty("currentSchema", "sharepoint"));
+
             Map<String, Object> schema = new HashMap<String, Object>();
-            schema.put("name", "sharepoint");
+            schema.put("name", schemaName);
             schema.put("type", "custom");
             schema.put("factory", "org.apache.calcite.adapter.sharepoint.SharePointListSchemaFactory");
             schema.put("operand", operand);
@@ -91,7 +100,7 @@ public class SharePointListDriver extends org.apache.calcite.jdbc.Driver {
 
             Map<String, Object> model = new HashMap<String, Object>();
             model.put("version", "1.0");
-            model.put("defaultSchema", "sharepoint");
+            model.put("defaultSchema", schemaName);
             model.put("schemas", schemas);
 
             return new ObjectMapper().writeValueAsString(model);

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListEnumerator.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListEnumerator.java
@@ -12,6 +12,8 @@ package org.apache.calcite.adapter.sharepoint;
 
 import org.apache.calcite.linq4j.Enumerator;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -75,6 +77,8 @@ public class SharePointListEnumerator implements Enumerator<Object[]> {
     return row;
   }
 
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
   private Object convertValue(Object value, String type) {
     if (value == null) {
       return null;
@@ -92,15 +96,18 @@ public class SharePointListEnumerator implements Enumerator<Object[]> {
     case "boolean":
       return value instanceof Boolean ? value : Boolean.parseBoolean(value.toString());
     case "datetime":
-      // SharePoint returns dates as ISO 8601 strings
-      return java.sql.Timestamp.valueOf(value.toString().replace("T", " ").replace("Z", ""));
+      // Calcite represents TIMESTAMP as epoch milliseconds (a number); returning a
+      // java.sql.Timestamp object breaks the Avatica/JDBC cursor accessor. SharePoint returns
+      // ISO-8601 UTC strings.
+      return toEpochMillis(value.toString());
     case "lookup":
     case "user":
-      // These are complex objects in SharePoint, extract display value
+      // These are complex objects in SharePoint, extract the display value when present.
       if (value instanceof Map) {
         Map<String, Object> lookupValue = (Map<String, Object>) value;
-        return lookupValue.get("Title") != null
+        Object title = lookupValue.get("Title") != null
             ? lookupValue.get("Title") : lookupValue.get("LookupValue");
+        return title != null ? title.toString() : toJson(value);
       }
       return value.toString();
     case "multichoice":
@@ -110,6 +117,31 @@ public class SharePointListEnumerator implements Enumerator<Object[]> {
       }
       return value.toString();
     default:
+      // Coerce any remaining complex (object/array) value to JSON so it fits the VARCHAR column;
+      // scalars fall through to their string form.
+      if (value instanceof Map || value instanceof List) {
+        return toJson(value);
+      }
+      return value.toString();
+    }
+  }
+
+  /** Parses a SharePoint ISO-8601 datetime into epoch milliseconds. */
+  private static Long toEpochMillis(String value) {
+    try {
+      return java.time.Instant.parse(value).toEpochMilli();
+    } catch (RuntimeException e) {
+      // Fall back for values without an explicit zone/offset.
+      return java.sql.Timestamp.valueOf(
+          value.replace("T", " ").replace("Z", "")).getTime();
+    }
+  }
+
+  /** Serializes a complex SharePoint value to a JSON string. */
+  private static String toJson(Object value) {
+    try {
+      return JSON_MAPPER.writeValueAsString(value);
+    } catch (Exception e) {
       return value.toString();
     }
   }

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListMetadata.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListMetadata.java
@@ -10,25 +10,54 @@
  */
 package org.apache.calcite.adapter.sharepoint;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Metadata for a SharePoint list.
  */
 public class SharePointListMetadata {
+  // List templates whose "rows" are not plain list items (files, survey responses, threads), so
+  // INSERT/UPDATE/DELETE through the list-item API does not apply - they are exposed read-only.
+  private static final List<String> READ_ONLY_TEMPLATES = Arrays.asList(
+      "documentlibrary", "picturelibrary", "webpagelibrary", "mysitedocumentlibrary",
+      "xmlform", "survey", "discussionboard");
+
   private final String listId;
   private final String listName;       // SQL-friendly name (lowercase)
   private final String displayName;    // Original SharePoint display name
   private final String entityTypeName;
   private final List<SharePointColumn> columns;
+  private final String template;       // Graph list template (e.g. genericList, documentLibrary)
 
   public SharePointListMetadata(String listId, String displayName, String entityTypeName,
       List<SharePointColumn> columns) {
+    this(listId, displayName, entityTypeName, columns, null);
+  }
+
+  public SharePointListMetadata(String listId, String displayName, String entityTypeName,
+      List<SharePointColumn> columns, String template) {
     this.listId = listId;
     this.displayName = displayName;
     this.listName = SharePointNameConverter.toSqlName(displayName);
     this.entityTypeName = entityTypeName;
     this.columns = columns;
+    this.template = template;
+  }
+
+  public String getTemplate() {
+    return template;
+  }
+
+  /**
+   * Whether this list accepts writes (INSERT/UPDATE/DELETE) through the list-item API. Generic
+   * lists, task lists and calendars do; document/picture libraries, surveys and discussion boards
+   * do not. Unknown templates default to writable to preserve prior behaviour.
+   */
+  public boolean isWritable() {
+    return template == null
+        || !READ_ONLY_TEMPLATES.contains(template.toLowerCase(Locale.ROOT));
   }
 
   public String getListId() {

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListSchema.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListSchema.java
@@ -48,10 +48,29 @@ public class SharePointListSchema extends AbstractSchema {
     // Check if REST API should be used (default to Graph API)
     this.useRestApi = "rest".equalsIgnoreCase((String) authConfig.get("apiType"));
 
-    this.client = new MicrosoftGraphListClient(siteUrl, authenticator);
+    this.client = new MicrosoftGraphListClient(siteUrl, authenticator,
+        parseCacheTtlMillis(authConfig.get("metadataCacheTtl")));
     this.restClient = new SharePointRestListClient(siteUrl, authenticator);
     this.tableMap = new ConcurrentHashMap<>(createTableMap());
     this.metadataSchema = new SharePointMetadataSchema(this, "sharepoint", "public");
+  }
+
+  /**
+   * Parses the {@code metadataCacheTtl} operand (in seconds) into milliseconds for the list
+   * discovery cache. Defaults to 5 minutes; a negative value means "never expire" and {@code 0}
+   * disables caching.
+   */
+  private static long parseCacheTtlMillis(Object value) {
+    if (value == null) {
+      return 300_000L;
+    }
+    long seconds;
+    try {
+      seconds = Long.parseLong(value.toString().trim());
+    } catch (NumberFormatException e) {
+      return 300_000L;
+    }
+    return seconds < 0 ? -1L : seconds * 1000L;
   }
 
   /**
@@ -179,6 +198,8 @@ public class SharePointListSchema extends AbstractSchema {
    * Refreshes the schema to pick up newly created or deleted lists.
    */
   public void refresh() {
+    // Drop the cached discovery so newly created/dropped lists are picked up immediately.
+    client.invalidateListCache();
     // Clear and rebuild the table map
     tableMap.clear();
     tableMap.putAll(createTableMap());

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListTable.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListTable.java
@@ -248,7 +248,7 @@ public class SharePointListTable extends AbstractQueryableTable
         Object value = row[i + 1]; // +1 to skip ID column
 
         if (value != null) {
-          fields.put(column.getInternalName(), value);
+          fields.put(column.getInternalName(), formatForWrite(column, value));
         }
       }
 
@@ -270,10 +270,27 @@ public class SharePointListTable extends AbstractQueryableTable
         Object value = row[i + 1]; // +1 to skip ID column
 
         // For updates, include all fields (even nulls might be intentional)
-        fields.put(column.getInternalName(), value);
+        fields.put(column.getInternalName(), formatForWrite(column, value));
       }
 
       return fields;
+    }
+
+    /**
+     * Converts a column value into the form SharePoint expects on write. Calcite passes a TIMESTAMP
+     * as epoch milliseconds, but the Graph/REST API expects an ISO-8601 string, so format datetime
+     * columns accordingly. Other types pass through unchanged.
+     */
+    private Object formatForWrite(SharePointColumn column, Object value) {
+      if (value != null && "datetime".equalsIgnoreCase(column.getType())) {
+        if (value instanceof Number) {
+          return java.time.Instant.ofEpochMilli(((Number) value).longValue()).toString();
+        }
+        if (value instanceof java.sql.Timestamp) {
+          return ((java.sql.Timestamp) value).toInstant().toString();
+        }
+      }
+      return value;
     }
   }
 

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListTable.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/SharePointListTable.java
@@ -113,6 +113,7 @@ public class SharePointListTable extends AbstractQueryableTable
   }
 
   @Override public @Nullable Collection getModifiableCollection() {
+    checkWritable();
     return new SharePointModifiableCollection();
   }
 
@@ -120,8 +121,21 @@ public class SharePointListTable extends AbstractQueryableTable
       RelOptTable table, Prepare.CatalogReader catalogReader, RelNode child,
       TableModify.Operation operation, @Nullable List<String> updateColumnList,
       @Nullable List<RexNode> sourceExpressionList, boolean flattened) {
+    checkWritable();
     return LogicalTableModify.create(table, catalogReader, child, operation,
         updateColumnList, sourceExpressionList, flattened);
+  }
+
+  /**
+   * Rejects writes to list types whose rows are not plain list items (document/picture libraries,
+   * surveys, discussion boards). Generic lists, task lists and calendars remain writable.
+   */
+  private void checkWritable() {
+    if (!metadata.isWritable()) {
+      throw new UnsupportedOperationException(
+          "SharePoint list '" + metadata.getDisplayName() + "' (template "
+              + metadata.getTemplate() + ") is read-only");
+    }
   }
 
   /**

--- a/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/auth/CertificateAuth.java
+++ b/sharepoint-list/src/main/java/org/apache/calcite/adapter/sharepoint/auth/CertificateAuth.java
@@ -166,17 +166,30 @@ public class CertificateAuth implements SharePointAuth {
         keyStore.getKey(keyStore.aliases().nextElement(),
         certificatePassword.toCharArray());
 
-    return Jwts.builder()
-        .setId(UUID.randomUUID().toString())
-        .setIssuer(clientId)
-        .setSubject(clientId)
-        .setAudience("https://login.microsoftonline.com/" + tenantId
-            + "/oauth2/v2.0/token")
-        .setIssuedAt(new java.util.Date(now * 1000))
-        .setNotBefore(new java.util.Date(now * 1000))
-        .setExpiration(new java.util.Date((now + 600) * 1000))
-        .claim("x5t", thumbprint)
-        .signWith(key, SignatureAlgorithm.RS256)
-        .compact();
+    // JJWT resolves its implementation (DefaultJwtBuilder) via the thread context classloader.
+    // Under an isolated plugin classloader (e.g. Trino's PluginClassLoader) that loads the impl
+    // from the wrong loader and fails with a ClassCastException, so pin the TCCL to this class's
+    // loader for the duration of the build.
+    Thread thread = Thread.currentThread();
+    ClassLoader originalLoader = thread.getContextClassLoader();
+    try {
+      thread.setContextClassLoader(CertificateAuth.class.getClassLoader());
+      return Jwts.builder()
+          // Azure AD requires the certificate SHA-1 thumbprint in the JWT *header* (x5t), not as a
+          // payload claim, otherwise it rejects the assertion with AADSTS5002723.
+          .setHeaderParam("x5t", thumbprint)
+          .setId(UUID.randomUUID().toString())
+          .setIssuer(clientId)
+          .setSubject(clientId)
+          .setAudience("https://login.microsoftonline.com/" + tenantId
+              + "/oauth2/v2.0/token")
+          .setIssuedAt(new java.util.Date(now * 1000))
+          .setNotBefore(new java.util.Date(now * 1000))
+          .setExpiration(new java.util.Date((now + 600) * 1000))
+          .signWith(key, SignatureAlgorithm.RS256)
+          .compact();
+    } finally {
+      thread.setContextClassLoader(originalLoader);
+    }
   }
 }

--- a/trino-calcite/README.md
+++ b/trino-calcite/README.md
@@ -1,0 +1,81 @@
+# Trino Calcite Connector
+
+A generic [Trino](https://trino.io) connector that exposes any Apache Calcite model — and therefore
+any Calcite adapter (File, GovData, SharePoint, …) — to Trino as a SQL catalog. It is built on
+Trino's `trino-base-jdbc` framework and wraps the generic Calcite JDBC driver
+(`org.apache.calcite.jdbc.Driver`, `jdbc:calcite:`).
+
+## Requirements
+
+A Trino plugin must be built against the **exact** SPI version of the server it is deployed into.
+This module targets the version pinned by `trino.version` in the repo's `gradle.properties`
+(currently **481**, which requires **Java 25**). The module builds with its own Java 25 toolchain;
+the Calcite driver it bundles is Java 8 bytecode and runs unchanged on the Trino JVM.
+
+## Build
+
+```bash
+./gradlew :trino-calcite:trinoPlugin
+# Output: trino-calcite/build/distributions/trino-calcite-plugin-*.zip
+```
+
+The archive is a Trino **plugin directory** (a directory of jars, not a fat jar): `trino-spi` and
+the other artifacts Trino provides to plugins parent-first are excluded; the Calcite driver and
+`trino-base-jdbc` are bundled.
+
+## Install
+
+Unzip the archive into the Trino server's `plugin/` directory:
+
+```bash
+unzip trino-calcite-plugin-*.zip -d "$TRINO_HOME/plugin/"
+# yields $TRINO_HOME/plugin/trino-calcite/<jars>
+```
+
+## Configure a catalog
+
+Create `etc/catalog/<name>.properties`:
+
+```properties
+connector.name=calcite
+connection-url=jdbc:calcite:model=/etc/trino/models/example.json
+# Required: Calcite matches identifiers case-sensitively, but its Avatica metadata reports
+# storesUpperCaseIdentifiers()=true. Without this, Trino upper-cases names and finds nothing.
+case-insensitive-name-matching=true
+```
+
+`connection-url` is any `jdbc:calcite:` URL. An inline model also works:
+`connection-url=jdbc:calcite:model=inline:{...}`.
+
+Name your Calcite schemas, tables and columns in **lower case** — Trino folds unquoted identifiers
+to lower case.
+
+## Example queries
+
+```sql
+SHOW SCHEMAS FROM calcite;
+SHOW TABLES FROM calcite.test;
+SELECT id, name, amount FROM calcite.test.events WHERE active = true;
+```
+
+## Behaviour and limitations
+
+- **Pushdown.** Built on `trino-base-jdbc`: Trino pushes projection and simple predicate (domain)
+  filters down to the Calcite JDBC source as SQL, so Trino receives only the rows it asked for.
+  Aggregations and joins are executed by Trino. What Calcite does with that SQL — and how far it
+  pushes toward its own backing sources — is internal to the model and not the connector's concern.
+- **Type mapping** ([CalciteClient.java](src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java))
+  covers the standard `java.sql.Types` Calcite emits (boolean, integer family, real/double,
+  decimal, char/varchar, varbinary, date, time, timestamp). Unmapped remote types are skipped; set
+  `unsupported-type-handling=CONVERT_TO_VARCHAR` on the catalog to surface them as varchar instead.
+
+## Testing
+
+```bash
+./gradlew :trino-calcite:test -PincludeTags=integration
+```
+
+[TestCalciteConnector](src/test/java/org/apache/calcite/adapter/trino/TestCalciteConnector.java)
+spins up an in-process Trino cluster (`trino-testing`) over an in-memory Calcite model and asserts
+on `SHOW TABLES`, projection, filtering, aggregation, and that the predicate + projection are pushed
+down into the Calcite JDBC scan (no Trino-side `Filter` node).

--- a/trino-calcite/build.gradle.kts
+++ b/trino-calcite/build.gradle.kts
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Generic Trino connector over the Calcite JDBC driver (jdbc:calcite:).
+//
+// IMPORTANT: Trino's SPI requires a modern JDK, so this module overrides the repo-wide Java 8
+// convention with its own toolchain. The Calcite driver jars it wraps are Java 8 bytecode and
+// run unchanged on the Trino JVM. A Trino plugin must be built against the exact SPI version of
+// the server it deploys into; the version is pinned by `trino.version` in gradle.properties.
+
+val trinoVersion = providers.gradleProperty("trino.version").get()
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+// `--release 25` makes javac ignore the inherited source/target 1.8 set by the root convention.
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
+}
+
+// Opt out of the legacy code-quality gates the root build applies to every Java module. Their
+// bytecode tooling (forbiddenapis/jandex use an older ASM) cannot parse Java 25 class files, and
+// the autostyle ruleset targets the Calcite source conventions, not Trino-style code.
+tasks.matching {
+    val n = it.name.lowercase()
+    n.contains("forbidden") || n.contains("jandex") || n.contains("autostyle")
+}.configureEach { enabled = false }
+
+// Jetty 12.1.x offers a Brotli compression provider that requires a platform-native library not
+// present in this test environment; drop it so the in-process HTTP server falls back to gzip.
+configurations.testRuntimeClasspath {
+    exclude(group = "org.eclipse.jetty.compression", module = "jetty-compression-brotli")
+}
+
+// The in-process Trino server (trino-testing) needs the same JVM flags as a real Trino launch:
+// the incubating Vector API, several add-opens, native access and unsafe memory access on JDK 25.
+tasks.withType<Test>().configureEach {
+    maxHeapSize = "2g"
+    jvmArgs(
+        "--add-modules=jdk.incubator.vector",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--enable-native-access=ALL-UNNAMED",
+        "--sun-misc-unsafe-memory-access=allow",
+        "-Djdk.attach.allowAttachSelf=true"
+    )
+}
+
+dependencies {
+    // trino-base-jdbc pulls io.airlift:http-client -> Jetty 12.1.8 onto the compile classpath,
+    // but the in-process Trino server (test runtime) is compiled against Jetty 12.1.9. Because the
+    // root build pins runtime versions to the compile classpath, bump the compile-side Jetty so the
+    // pin lands on 12.1.9 (otherwise the server hits a jetty-http ComplianceUtils NoSuchMethodError).
+    constraints {
+        listOf(
+            "org.eclipse.jetty:jetty-http",
+            "org.eclipse.jetty:jetty-client",
+            "org.eclipse.jetty:jetty-io",
+            "org.eclipse.jetty:jetty-util",
+            "org.eclipse.jetty.http2:jetty-http2-common",
+            "org.eclipse.jetty.http2:jetty-http2-hpack",
+            "org.eclipse.jetty.http2:jetty-http2-client",
+            "org.eclipse.jetty.http2:jetty-http2-client-transport",
+            "org.eclipse.jetty.compression:jetty-compression-common",
+            "org.eclipse.jetty.compression:jetty-compression-gzip"
+        ).forEach { api(it) { version { require("12.1.9") } } }
+    }
+
+    // Provided by the Trino server at runtime via the plugin's parent classloader - must NOT be bundled.
+    compileOnly("io.trino:trino-spi:$trinoVersion")
+
+    // The JDBC connector framework. Bundled into the plugin directory. Brings Guice, Airlift
+    // configuration, OpenTelemetry and Jackson onto the compile classpath transitively.
+    api("io.trino:trino-base-jdbc:$trinoVersion")
+
+    // The backing driver: org.apache.calcite.jdbc.Driver (jdbc:calcite:model=...). Bundled.
+    implementation(project(":core"))
+
+    testImplementation("io.trino:trino-spi:$trinoVersion")
+    testImplementation("io.trino:trino-testing:$trinoVersion")
+    testImplementation("io.trino:trino-main:$trinoVersion")
+    // trino-testing pulls JUnit Platform 6.x; supply a matching launcher so Gradle 8.7 uses it
+    // instead of its older bundled launcher (otherwise TagFilter hits a NoSuchMethodError).
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// Assemble a Trino plugin directory (directory-of-jars, not a fat jar). Trino loads plugins from
+// `<trino>/plugin/<name>/`; unzip the archive there. trino-spi is compileOnly so it is already
+// absent from runtimeClasspath; the names below are the other artifacts Trino exposes to plugins
+// parent-first and which therefore must NOT be bundled. NOTE: verify the provided set against a
+// real Trino server for the pinned version before shipping.
+val trinoProvidedPrefixes = listOf("slice-", "jackson-annotations-", "opentelemetry-api-",
+        "opentelemetry-context-", "jol-core-")
+
+tasks.register<Zip>("trinoPlugin") {
+    group = "distribution"
+    description = "Builds the Trino plugin directory archive for the calcite connector."
+    archiveBaseName.set("trino-calcite-plugin")
+    into("trino-calcite") {
+        from(tasks.named("jar"))
+        from(configurations["runtimeClasspath"].filter { file ->
+            trinoProvidedPrefixes.none { file.name.startsWith(it) }
+        })
+    }
+}

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/AutoCommitConnectionFactory.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/AutoCommitConnectionFactory.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.spi.connector.ConnectorSession;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Wraps a {@link ConnectionFactory} to present a non-transactional connection, which Trino's JDBC
+ * write path requires but Calcite does not provide.
+ *
+ * <p>Calcite's JDBC connection reports {@code autoCommit=false} and throws
+ * {@link UnsupportedOperationException} on {@code commit()}/{@code rollback()}. Trino, however,
+ * verifies {@code autoCommit} is true before an INSERT and calls {@code commit()} when the writer
+ * finishes. Since the backing adapters (e.g. SharePoint) apply each row immediately and have no
+ * transactions, this proxy reports {@code autoCommit=true} and turns {@code setAutoCommit},
+ * {@code commit} and {@code rollback} into no-ops. Reads are unaffected.
+ */
+public class AutoCommitConnectionFactory
+        implements ConnectionFactory
+{
+    private final ConnectionFactory delegate;
+
+    public AutoCommitConnectionFactory(ConnectionFactory delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        Connection connection = delegate.openConnection(session);
+        return (Connection) Proxy.newProxyInstance(
+                AutoCommitConnectionFactory.class.getClassLoader(),
+                new Class<?>[] {Connection.class},
+                new NonTransactionalHandler(connection));
+    }
+
+    @Override
+    public void close()
+            throws SQLException
+    {
+        delegate.close();
+    }
+
+    private static final class NonTransactionalHandler
+            implements InvocationHandler
+    {
+        private final Connection connection;
+
+        NonTransactionalHandler(Connection connection)
+        {
+            this.connection = connection;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args)
+                throws Throwable
+        {
+            switch (method.getName()) {
+            case "getAutoCommit":
+                return Boolean.TRUE;
+            case "setAutoCommit":
+            case "commit":
+            case "rollback":
+                return null;
+            default:
+                try {
+                    return method.invoke(connection, args);
+                }
+                catch (InvocationTargetException e) {
+                    throw e.getCause();
+                }
+            }
+        }
+    }
+}

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
@@ -183,9 +183,19 @@ public class CalciteClient
         case Types.TIME:
             return Optional.of(io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping(
                     createTimeType(min(typeHandle.decimalDigits().orElse(3), TimeType.MAX_PRECISION))));
-        case Types.TIMESTAMP:
-            return Optional.of(timestampColumnMapping(
-                    createTimestampType(min(typeHandle.decimalDigits().orElse(3), TimestampType.MAX_PRECISION))));
+        case Types.TIMESTAMP: {
+            // Calcite/Avatica exposes TIMESTAMP via a number-based cursor accessor, which does not
+            // support Trino's default read (getObject(LocalDateTime.class)) and fails with
+            // "cannot convert to Object". Read the raw epoch milliseconds via getLong instead and
+            // scale to the microseconds a short Trino timestamp expects. (Calcite timestamps are
+            // millisecond precision, so this is always a short timestamp.)
+            int precision = min(typeHandle.decimalDigits().orElse(3), 6);
+            TimestampType timestampType = createTimestampType(precision);
+            return Optional.of(ColumnMapping.longMapping(
+                    timestampType,
+                    (resultSet, columnIndex) -> resultSet.getLong(columnIndex) * 1000L,
+                    timestampWriteFunction(timestampType)));
+        }
         default:
             // Unknown remote type: skip the column. Set unsupported-type-handling to
             // CONVERT_TO_VARCHAR on the catalog to surface it as varchar instead.

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
@@ -191,10 +191,13 @@ public class CalciteClient
             // millisecond precision, so this is always a short timestamp.)
             int precision = min(typeHandle.decimalDigits().orElse(3), 6);
             TimestampType timestampType = createTimestampType(precision);
+            // Read: Calcite exposes TIMESTAMP as epoch millis via a number accessor; scale to the
+            // microseconds a short Trino timestamp uses. Write: Trino's default timestamp write
+            // binds a LocalDateTime, but Calcite's INSERT expects a Long (millis), so bind that.
             return Optional.of(ColumnMapping.longMapping(
                     timestampType,
                     (resultSet, columnIndex) -> resultSet.getLong(columnIndex) * 1000L,
-                    timestampWriteFunction(timestampType)));
+                    (statement, index, value) -> statement.setObject(index, value / 1000L)));
         }
         default:
             // Unknown remote type: skip the column. Set unsupported-type-handling to

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClient.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import com.google.inject.Inject;
+
+import io.trino.plugin.base.mapping.IdentifierMapping;
+import io.trino.plugin.jdbc.BaseJdbcClient;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.plugin.jdbc.logging.RemoteQueryModifier;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.TimeType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.Optional;
+
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.dateColumnMappingUsingLocalDate;
+import static io.trino.plugin.jdbc.StandardColumnMappings.dateWriteFunctionUsingLocalDate;
+import static io.trino.plugin.jdbc.StandardColumnMappings.decimalColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.defaultCharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.defaultVarcharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.longTimestampWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timeWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.MAX_PRECISION;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.Math.min;
+import static java.lang.String.format;
+
+/**
+ * {@link io.trino.plugin.jdbc.JdbcClient} for the generic Calcite JDBC driver.
+ *
+ * <p>Calcite exposes its data over JDBC using standard {@link java.sql.Types}, so the type
+ * mappings here delegate to Trino's {@link io.trino.plugin.jdbc.StandardColumnMappings}. The
+ * underlying Calcite adapters (e.g. SharePoint) are full-scan with no predicate/projection
+ * pushdown, so Trino reads all rows and filters locally - the default {@link BaseJdbcClient}
+ * behaviour (no pushdown) is intentionally retained.
+ */
+public class CalciteClient
+        extends BaseJdbcClient
+{
+    @Inject
+    public CalciteClient(
+            BaseJdbcConfig config,
+            @ForBaseJdbc ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
+            IdentifierMapping identifierMapping,
+            RemoteQueryModifier queryModifier)
+    {
+        // Calcite quotes identifiers with double quotes; this connector is read-oriented, so
+        // non-transactional writes (supportsRetries = false).
+        super("\"", connectionFactory, queryBuilder, config.getJdbcTypesMappedToVarchar(),
+                identifierMapping, queryModifier, false);
+    }
+
+    @Override
+    public Optional<ColumnMapping> toColumnMapping(
+            ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        Optional<ColumnMapping> forced = getForcedMappingToVarchar(typeHandle);
+        if (forced.isPresent()) {
+            return forced;
+        }
+
+        switch (typeHandle.jdbcType()) {
+        case Types.BIT:
+        case Types.BOOLEAN:
+            return Optional.of(booleanColumnMapping());
+        case Types.TINYINT:
+            return Optional.of(tinyintColumnMapping());
+        case Types.SMALLINT:
+            return Optional.of(smallintColumnMapping());
+        case Types.INTEGER:
+            return Optional.of(integerColumnMapping());
+        case Types.BIGINT:
+            return Optional.of(bigintColumnMapping());
+        case Types.REAL:
+            return Optional.of(realColumnMapping());
+        case Types.FLOAT:
+        case Types.DOUBLE:
+            return Optional.of(doubleColumnMapping());
+        case Types.NUMERIC:
+        case Types.DECIMAL: {
+            int precision = typeHandle.columnSize().orElse(MAX_PRECISION);
+            int scale = Math.max(typeHandle.decimalDigits().orElse(0), 0);
+            if (precision < 1 || precision > MAX_PRECISION) {
+                precision = MAX_PRECISION;
+            }
+            if (scale > precision) {
+                scale = precision;
+            }
+            return Optional.of(decimalColumnMapping(createDecimalType(precision, scale)));
+        }
+        case Types.CHAR:
+        case Types.NCHAR: {
+            int size = typeHandle.columnSize().orElse(0);
+            if (size <= 0 || size > CharType.MAX_LENGTH) {
+                // Unspecified/oversized CHAR: fall back to unbounded varchar rather than fail.
+                return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), true));
+            }
+            return Optional.of(defaultCharColumnMapping(size, true));
+        }
+        case Types.VARCHAR:
+        case Types.NVARCHAR:
+        case Types.LONGVARCHAR:
+        case Types.LONGNVARCHAR: {
+            // Calcite reports an unspecified precision (<= 0) for unbounded VARCHAR; map those and
+            // oversized lengths to an unbounded varchar to avoid an invalid VARCHAR length.
+            int size = typeHandle.columnSize().orElse(0);
+            if (size <= 0 || size > VarcharType.MAX_LENGTH) {
+                return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), true));
+            }
+            return Optional.of(defaultVarcharColumnMapping(size, true));
+        }
+        case Types.BINARY:
+        case Types.VARBINARY:
+        case Types.LONGVARBINARY:
+            return Optional.of(varbinaryColumnMapping());
+        case Types.DATE:
+            return Optional.of(dateColumnMappingUsingLocalDate());
+        case Types.TIME:
+            return Optional.of(io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping(
+                    createTimeType(min(typeHandle.decimalDigits().orElse(3), TimeType.MAX_PRECISION))));
+        case Types.TIMESTAMP:
+            return Optional.of(timestampColumnMapping(
+                    createTimestampType(min(typeHandle.decimalDigits().orElse(3), TimestampType.MAX_PRECISION))));
+        default:
+            // Unknown remote type: skip the column. Set unsupported-type-handling to
+            // CONVERT_TO_VARCHAR on the catalog to surface it as varchar instead.
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        if (type == BOOLEAN) {
+            return WriteMapping.booleanMapping("boolean", booleanWriteFunction());
+        }
+        if (type == TINYINT) {
+            return WriteMapping.longMapping("tinyint", tinyintWriteFunction());
+        }
+        if (type == SMALLINT) {
+            return WriteMapping.longMapping("smallint", smallintWriteFunction());
+        }
+        if (type == INTEGER) {
+            return WriteMapping.longMapping("integer", integerWriteFunction());
+        }
+        if (type == BIGINT) {
+            return WriteMapping.longMapping("bigint", bigintWriteFunction());
+        }
+        if (type == REAL) {
+            return WriteMapping.longMapping("real", realWriteFunction());
+        }
+        if (type == DOUBLE) {
+            return WriteMapping.doubleMapping("double precision", doubleWriteFunction());
+        }
+        if (type instanceof DecimalType decimalType) {
+            String dataType = format("decimal(%s, %s)", decimalType.getPrecision(), decimalType.getScale());
+            if (decimalType.isShort()) {
+                return WriteMapping.longMapping(dataType, shortDecimalWriteFunction(decimalType));
+            }
+            return WriteMapping.objectMapping(dataType, longDecimalWriteFunction(decimalType));
+        }
+        if (type instanceof CharType charType) {
+            return WriteMapping.sliceMapping("char(" + charType.getLength() + ")", charWriteFunction());
+        }
+        if (type instanceof VarcharType varcharType) {
+            String dataType = varcharType.isUnbounded()
+                    ? "varchar"
+                    : "varchar(" + varcharType.getBoundedLength() + ")";
+            return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
+        }
+        if (type == VARBINARY) {
+            return WriteMapping.sliceMapping("varbinary", varbinaryWriteFunction());
+        }
+        if (type == DATE) {
+            return WriteMapping.longMapping("date", dateWriteFunctionUsingLocalDate());
+        }
+        if (type instanceof TimeType timeType) {
+            return WriteMapping.longMapping("time(" + timeType.getPrecision() + ")",
+                    timeWriteFunction(timeType.getPrecision()));
+        }
+        if (type instanceof TimestampType timestampType) {
+            String dataType = "timestamp(" + timestampType.getPrecision() + ")";
+            if (timestampType.isShort()) {
+                return WriteMapping.longMapping(dataType, timestampWriteFunction(timestampType));
+            }
+            return WriteMapping.objectMapping(dataType,
+                    longTimestampWriteFunction(timestampType, timestampType.getPrecision()));
+        }
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+    }
+}

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClientModule.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClientModule.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+
+/**
+ * Guice module wiring the generic Calcite JDBC connector: it binds {@link CalciteClient} as the
+ * {@link JdbcClient} and provides a {@link ConnectionFactory} backed by the Calcite JDBC driver.
+ *
+ * <p>The {@code connection-url} (a {@code jdbc:calcite:...} URL, typically
+ * {@code jdbc:calcite:model=/path/model.json}) is read from {@link BaseJdbcConfig}.
+ *
+ * <p>Calcite's Avatica metadata reports {@code storesUpperCaseIdentifiers()==true}, but Calcite
+ * matches identifiers case-sensitively exactly as declared in the model. Set
+ * {@code case-insensitive-name-matching=true} on the catalog so Trino resolves names against the
+ * actual remote names instead of upper-casing them.
+ */
+public class CalciteClientModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        // BaseJdbcConfig (and thus connection-url) is bound by the framework's JdbcModule;
+        // we only need to bind the client implementation here. (Case-insensitive name matching is
+        // a catalog property - see the class javadoc - because the framework decides whether to
+        // install the caching identifier mapping by reading that config at module-setup time.)
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
+                .to(CalciteClient.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory connectionFactory(
+            BaseJdbcConfig config,
+            CredentialProvider credentialProvider,
+            OpenTelemetry openTelemetry)
+    {
+        return DriverConnectionFactory.builder(
+                        new org.apache.calcite.jdbc.Driver(),
+                        config.getConnectionUrl(),
+                        credentialProvider)
+                .setOpenTelemetry(openTelemetry)
+                .build();
+    }
+}

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClientModule.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalciteClientModule.java
@@ -64,11 +64,12 @@ public class CalciteClientModule
             CredentialProvider credentialProvider,
             OpenTelemetry openTelemetry)
     {
-        return DriverConnectionFactory.builder(
+        return new AutoCommitConnectionFactory(
+                DriverConnectionFactory.builder(
                         new org.apache.calcite.jdbc.Driver(),
                         config.getConnectionUrl(),
                         credentialProvider)
                 .setOpenTelemetry(openTelemetry)
-                .build();
+                .build());
     }
 }

--- a/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalcitePlugin.java
+++ b/trino-calcite/src/main/java/org/apache/calcite/adapter/trino/CalcitePlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import io.trino.plugin.jdbc.JdbcPlugin;
+
+/**
+ * Trino plugin that exposes any Apache Calcite model (and therefore any Calcite adapter -
+ * File, GovData, SharePoint, ...) to Trino through the generic Calcite JDBC driver
+ * ({@code jdbc:calcite:model=...}).
+ *
+ * <p>The connector is named {@code calcite}; configure a catalog with
+ * {@code connector.name=calcite} and {@code connection-url=jdbc:calcite:model=/path/model.json}.
+ */
+public class CalcitePlugin
+        extends JdbcPlugin
+{
+    public CalcitePlugin()
+    {
+        super("calcite", CalciteClientModule::new);
+    }
+}

--- a/trino-calcite/src/main/resources/META-INF/services/io.trino.spi.Plugin
+++ b/trino-calcite/src/main/resources/META-INF/services/io.trino.spi.Plugin
@@ -1,0 +1,1 @@
+org.apache.calcite.adapter.trino.CalcitePlugin

--- a/trino-calcite/src/test/java/org/apache/calcite/adapter/trino/TestCalciteConnector.java
+++ b/trino-calcite/src/test/java/org/apache/calcite/adapter/trino/TestCalciteConnector.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import com.google.common.collect.ImmutableMap;
+
+import io.trino.Session;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end test that registers the generic {@link CalcitePlugin} against an in-memory Calcite
+ * model ({@link TestingCalciteSchemaFactory}) and runs SQL through the full Trino stack. Exercises
+ * the riskiest integration point: schema/table/column discovery over Avatica JDBC metadata plus
+ * {@link CalciteClient}'s type mapping.
+ */
+@Tag("integration")
+class TestCalciteConnector
+        extends AbstractTestQueryFramework
+{
+    private static final String MODEL_JSON =
+            "{\"version\":\"1.0\",\"defaultSchema\":\"test\",\"schemas\":[{"
+                    + "\"name\":\"test\",\"type\":\"custom\","
+                    + "\"factory\":\"org.apache.calcite.adapter.trino.TestingCalciteSchemaFactory\","
+                    + "\"operand\":{}}]}";
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("calcite")
+                .setSchema("test")
+                .build();
+        QueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        queryRunner.installPlugin(new CalcitePlugin());
+        queryRunner.createCatalog("calcite", "calcite", ImmutableMap.of(
+                "connection-url", "jdbc:calcite:model=inline:" + MODEL_JSON,
+                "case-insensitive-name-matching", "true"));
+        return queryRunner;
+    }
+
+    @Test
+    void testShowTables()
+    {
+        MaterializedResult tables = computeActual("SHOW TABLES FROM calcite.test");
+        assertTrue(tables.getOnlyColumnAsSet().contains("events"),
+                "expected 'events' table, got: " + tables.getOnlyColumnAsSet());
+    }
+
+    @Test
+    void testSelectAll()
+    {
+        MaterializedResult result = computeActual("SELECT id, name, active, amount FROM events ORDER BY id");
+        assertEquals(3, result.getRowCount());
+        assertEquals(1, result.getMaterializedRows().get(0).getField(0));
+        assertEquals("alpha", result.getMaterializedRows().get(0).getField(1));
+        assertEquals(true, result.getMaterializedRows().get(0).getField(2));
+        assertEquals(10.5, result.getMaterializedRows().get(0).getField(3));
+    }
+
+    @Test
+    void testPredicateAndProjectionPushedDown()
+    {
+        // The connector pushes the WHERE predicate and the projection down to the Calcite JDBC
+        // source: the scan carries a constraint on the filtered column and requests only the
+        // projected column, with no Trino-side Filter node.
+        String plan = (String) computeActual(
+                "EXPLAIN SELECT name FROM events WHERE active = true").getOnlyValue();
+        assertTrue(plan.contains("constraint on [active]"),
+                "expected the predicate pushed into the JDBC scan, plan:\n" + plan);
+        assertFalse(plan.contains("Filter["),
+                "expected no Trino Filter node (predicate fully pushed down), plan:\n" + plan);
+    }
+
+    @Test
+    void testFilterAndAggregate()
+    {
+        // Filtering happens in Trino (the Calcite adapter does not push down predicates).
+        MaterializedResult count = computeActual("SELECT count(*) FROM events WHERE active = true");
+        assertEquals(2L, count.getMaterializedRows().get(0).getField(0));
+
+        MaterializedResult sum = computeActual("SELECT sum(amount) FROM events");
+        assertEquals(60.75, sum.getMaterializedRows().get(0).getField(0));
+    }
+}

--- a/trino-calcite/src/test/java/org/apache/calcite/adapter/trino/TestingCalciteSchemaFactory.java
+++ b/trino-calcite/src/test/java/org/apache/calcite/adapter/trino/TestingCalciteSchemaFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Linq4j;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaFactory;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A self-contained Calcite {@link SchemaFactory} used only by the connector integration test. It
+ * exposes a single in-memory {@code events} table with assorted typed columns, so the test can
+ * drive the whole Trino -&gt; CalciteClient -&gt; Calcite JDBC path without any external data
+ * source (and therefore no Hadoop/Parquet dependency).
+ */
+public class TestingCalciteSchemaFactory
+        implements SchemaFactory
+{
+    @Override
+    public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand)
+    {
+        return new AbstractSchema()
+        {
+            @Override
+            protected Map<String, Table> getTableMap()
+            {
+                return Map.of("events", new EventsTable());
+            }
+        };
+    }
+
+    /** Three-row, four-column in-memory table. */
+    public static final class EventsTable
+            extends AbstractTable
+            implements ScannableTable
+    {
+        @Override
+        public RelDataType getRowType(RelDataTypeFactory typeFactory)
+        {
+            return typeFactory.builder()
+                    .add("id", SqlTypeName.INTEGER)
+                    .add("name", SqlTypeName.VARCHAR)
+                    .add("active", SqlTypeName.BOOLEAN)
+                    .add("amount", SqlTypeName.DOUBLE)
+                    .build();
+        }
+
+        @Override
+        public Enumerable<Object[]> scan(DataContext root)
+        {
+            List<Object[]> rows = Arrays.asList(
+                    new Object[] {1, "alpha", true, 10.5},
+                    new Object[] {2, "beta", false, 20.0},
+                    new Object[] {3, "gamma", true, 30.25});
+            return Linq4j.asEnumerable(rows);
+        }
+    }
+}

--- a/trino-sharepoint/README.md
+++ b/trino-sharepoint/README.md
@@ -1,0 +1,70 @@
+# Trino SharePoint Connector
+
+A [Trino](https://trino.io) connector that exposes SharePoint Lists as a SQL catalog. It is a thin
+wrapper over the generic [trino-calcite](../trino-calcite) connector: it reuses `CalciteClient` for
+type mapping and only swaps in the SharePoint JDBC driver
+(`org.apache.calcite.adapter.sharepoint.SharePointListDriver`) plus friendly catalog properties, so
+users never write a raw JDBC URL.
+
+## Requirements
+
+Like any Trino plugin, it must be built against the exact SPI version of the target server — the
+version pinned by `trino.version` in the repo's `gradle.properties` (currently **481**, **Java 25**).
+
+## Build & install
+
+```bash
+./gradlew :trino-sharepoint:trinoPlugin
+unzip trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip -d "$TRINO_HOME/plugin/"
+```
+
+## Configure a catalog
+
+Create `etc/catalog/sharepoint.properties`:
+
+```properties
+connector.name=sharepoint
+site-url=https://contoso.sharepoint.com/sites/mysite
+auth-type=CLIENT_CREDENTIALS
+client-id=<azure-ad-app-client-id>
+client-secret=<client-secret>
+tenant-id=<azure-ad-tenant-id>
+# SharePoint list/column names are matched case-sensitively by Calcite; keep this on.
+case-insensitive-name-matching=true
+```
+
+| Property | Description | Required |
+|----------|-------------|----------|
+| `site-url` | Full SharePoint site URL | Yes |
+| `auth-type` | `CLIENT_CREDENTIALS`, `USERNAME_PASSWORD`, `DEVICE_CODE`, `MANAGED_IDENTITY`, `CERTIFICATE` | Yes |
+| `client-id` | Azure AD app registration client ID | Yes |
+| `tenant-id` | Azure AD tenant ID | Yes |
+| `client-secret` | Client secret (`CLIENT_CREDENTIALS`) | Conditional |
+| `user` / `password` | UPN + password (`USERNAME_PASSWORD`) | Conditional |
+
+These map onto a `jdbc:sharepoint:…` URL for `SharePointListDriver`; see the
+[sharepoint-list adapter](../sharepoint-list/README.md) for Azure AD app-registration details.
+
+## Example queries
+
+```sql
+SHOW TABLES FROM sharepoint.sharepoint;
+SELECT title, status, due_date FROM sharepoint.sharepoint.project_tasks WHERE status = 'In Progress';
+```
+
+SharePoint list and column names are normalised to lower-case `snake_case` by the adapter
+(`SharePointNameConverter`).
+
+## Behaviour and limitations
+
+- **Pushdown.** Same as [trino-calcite](../trino-calcite) (it *is* that connector under the hood):
+  Trino pushes projection and simple predicate filters down to the Calcite JDBC source. How those
+  are executed below Calcite is internal to the SharePoint adapter, not the connector.
+- Authentication and API selection (Microsoft Graph vs SharePoint REST) are handled by the
+  underlying SharePoint adapter.
+
+## Testing
+
+A live SharePoint site (or recorded backend) is required for an end-to-end test; tag such tests as
+integration-only. The generic Trino↔Calcite path is covered by
+[trino-calcite](../trino-calcite)'s in-process test.

--- a/trino-sharepoint/README.md
+++ b/trino-sharepoint/README.md
@@ -1,26 +1,45 @@
 # Trino SharePoint Connector
 
-A [Trino](https://trino.io) connector that exposes SharePoint Lists as a SQL catalog. It is a thin
-wrapper over the generic [trino-calcite](../trino-calcite) connector: it reuses `CalciteClient` for
-type mapping and only swaps in the SharePoint JDBC driver
-(`org.apache.calcite.adapter.sharepoint.SharePointListDriver`) plus friendly catalog properties, so
-users never write a raw JDBC URL.
+A [Trino](https://trino.io) connector that exposes SharePoint Lists, document libraries, calendars
+and task lists as a SQL catalog. It is a thin wrapper over the generic
+[trino-calcite](../trino-calcite) connector: it reuses `CalciteClient` for type mapping and swaps in
+the SharePoint JDBC driver (`org.apache.calcite.adapter.sharepoint.SharePointListDriver`), exposing
+friendly catalog properties so you never write a raw JDBC URL.
 
 ## Requirements
 
-Like any Trino plugin, it must be built against the exact SPI version of the target server — the
-version pinned by `trino.version` in the repo's `gradle.properties` (currently **481**, **Java 25**).
+A Trino plugin must be built against the exact SPI version of the target server — the version pinned
+by `trino.version` in the repo's `gradle.properties` (currently **481**, which requires **Java 25**).
 
 ## Build & install
 
 ```bash
 ./gradlew :trino-sharepoint:trinoPlugin
+# Output: trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip
 unzip trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip -d "$TRINO_HOME/plugin/"
+# yields $TRINO_HOME/plugin/trino-sharepoint/<jars>; restart Trino
 ```
 
 ## Configure a catalog
 
-Create `etc/catalog/sharepoint.properties`:
+Create `etc/catalog/sharepoint.properties`. The required properties are always `connector.name`,
+`site-url`, `auth-type`, and `case-insensitive-name-matching=true`; the remaining properties depend
+on the auth type.
+
+### Certificate auth (recommended for automation)
+
+```properties
+connector.name=sharepoint
+site-url=https://contoso.sharepoint.com/sites/mysite
+auth-type=CERTIFICATE
+client-id=<azure-ad-app-client-id>
+tenant-id=<azure-ad-tenant-id>
+certificate-path=/etc/trino/sharepoint.pfx
+certificate-password=<pfx-password>
+case-insensitive-name-matching=true
+```
+
+### Client-secret auth
 
 ```properties
 connector.name=sharepoint
@@ -29,42 +48,84 @@ auth-type=CLIENT_CREDENTIALS
 client-id=<azure-ad-app-client-id>
 client-secret=<client-secret>
 tenant-id=<azure-ad-tenant-id>
-# SharePoint list/column names are matched case-sensitively by Calcite; keep this on.
 case-insensitive-name-matching=true
 ```
 
+### All properties
+
 | Property | Description | Required |
 |----------|-------------|----------|
+| `connector.name` | Always `sharepoint` | Yes |
 | `site-url` | Full SharePoint site URL | Yes |
-| `auth-type` | `CLIENT_CREDENTIALS`, `USERNAME_PASSWORD`, `DEVICE_CODE`, `MANAGED_IDENTITY`, `CERTIFICATE` | Yes |
+| `auth-type` | `CERTIFICATE`, `CLIENT_CREDENTIALS`, `USERNAME_PASSWORD`, `DEVICE_CODE`, `MANAGED_IDENTITY` | Yes |
+| `case-insensitive-name-matching` | Must be `true` — see note below | Yes |
 | `client-id` | Azure AD app registration client ID | Yes |
 | `tenant-id` | Azure AD tenant ID | Yes |
-| `client-secret` | Client secret (`CLIENT_CREDENTIALS`) | Conditional |
-| `user` / `password` | UPN + password (`USERNAME_PASSWORD`) | Conditional |
+| `certificate-path` | Path (inside the Trino server) to the PKCS#12 `.pfx` | `CERTIFICATE` |
+| `certificate-password` | Password for the `.pfx` | `CERTIFICATE` |
+| `thumbprint` | Cert SHA-1 thumbprint; omit to auto-compute from the `.pfx` | No |
+| `client-secret` | Client secret | `CLIENT_CREDENTIALS` |
+| `user` / `password` | UPN + password | `USERNAME_PASSWORD` |
+| `schema` | Schema name for the lists (default `sharepoint`) | No |
 
-These map onto a `jdbc:sharepoint:…` URL for `SharePointListDriver`; see the
-[sharepoint-list adapter](../sharepoint-list/README.md) for Azure AD app-registration details.
+> **`case-insensitive-name-matching=true` is required.** Calcite matches identifiers
+> case-sensitively, but its Avatica metadata reports `storesUpperCaseIdentifiers()=true`; without
+> this flag Trino upper-cases names and finds no tables.
+
+The catalog name is the properties filename (`sharepoint.properties` → catalog `sharepoint`); the
+schema defaults to `sharepoint`. So tables are addressed as `sharepoint.sharepoint.<list>`, or
+`sharepoint.<schema>.<list>` if you set `schema`.
+
+### Azure AD app registration
+
+- API permission **`Sites.ReadWrite.All` (Application)** on Microsoft Graph, with **admin consent**.
+- For `CERTIFICATE` auth, upload the **public** certificate to the app registration under
+  **Certificates & secrets → Certificates**. See the
+  [sharepoint-list adapter README](../sharepoint-list/README.md) for generating the `.pfx`.
 
 ## Example queries
 
 ```sql
+SHOW SCHEMAS FROM sharepoint;
 SHOW TABLES FROM sharepoint.sharepoint;
+SELECT title, start_time, end_time FROM sharepoint.sharepoint.calendar;
 SELECT title, status, due_date FROM sharepoint.sharepoint.project_tasks WHERE status = 'In Progress';
 ```
 
-SharePoint list and column names are normalised to lower-case `snake_case` by the adapter
-(`SharePointNameConverter`).
-
 ## Behaviour and limitations
 
-- **Pushdown.** Same as [trino-calcite](../trino-calcite) (it *is* that connector under the hood):
-  Trino pushes projection and simple predicate filters down to the Calcite JDBC source. How those
-  are executed below Calcite is internal to the SharePoint adapter, not the connector.
-- Authentication and API selection (Microsoft Graph vs SharePoint REST) are handled by the
-  underlying SharePoint adapter.
+- **Discovery is automatic.** Every non-hidden list, document library, calendar and task list in the
+  site is exposed as a table — no list names to configure. Names are normalised to lower-case
+  `snake_case`. Results are cached per site (default 5 minutes) so repeated queries don't re-crawl
+  the site on every connection.
+- **Column types.** SharePoint text/choice/lookup/user map to `VARCHAR`, numbers to `DOUBLE`,
+  integers to `INTEGER`, booleans to `BOOLEAN`, datetimes to `TIMESTAMP`. Complex column values
+  (recurrence, location, etc.) are returned as **JSON strings**.
+- **Writes are gated by list type.** Generic lists, task lists and calendars accept
+  `INSERT`/`UPDATE`/`DELETE`; document/picture libraries, surveys and discussion boards are
+  **read-only** (their rows aren't plain list items).
+- **Pushdown.** As with [trino-calcite](../trino-calcite), Trino pushes projection and simple
+  predicate filters down to the Calcite JDBC source; what happens below Calcite is the adapter's
+  concern, not the connector's.
 
-## Testing
+## Quick local test with Docker
 
-A live SharePoint site (or recorded backend) is required for an end-to-end test; tag such tests as
-integration-only. The generic Trino↔Calcite path is covered by
-[trino-calcite](../trino-calcite)'s in-process test.
+```bash
+# Build the plugin and stage it
+./gradlew :trino-sharepoint:trinoPlugin
+unzip -o trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip -d ./plugin
+# Run Trino with the plugin, catalog and cert mounted (or bake them into an image)
+docker run -d --name trino -p 8080:8080 \
+  -v "$PWD/plugin/trino-sharepoint:/usr/lib/trino/plugin/sharepoint" \
+  -v "$PWD/sharepoint.properties:/etc/trino/catalog/sharepoint.properties" \
+  -v "$PWD/sharepoint.pfx:/etc/trino/sharepoint.pfx" \
+  trinodb/trino:481
+docker exec trino trino --execute "SHOW TABLES FROM sharepoint.sharepoint"
+```
+
+> On Windows, bind-mount path translation can be flaky; baking the files into a small image
+> (`FROM trinodb/trino:481` + `COPY`) is more reliable.
+
+This connector was verified end-to-end this way (certificate auth, full list discovery, calendar
+reads). The generic Trino↔Calcite path also has an in-process test in
+[trino-calcite](../trino-calcite).

--- a/trino-sharepoint/build.gradle.kts
+++ b/trino-sharepoint/build.gradle.kts
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Trino connector for SharePoint Lists. A thin wrapper over the generic trino-calcite connector:
+// it reuses CalciteClient for type mapping and only swaps in the SharePoint JDBC driver plus
+// friendly catalog properties (site-url, auth-type, client-id, ...). See trino-calcite for the
+// toolchain rationale.
+
+val trinoVersion = providers.gradleProperty("trino.version").get()
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
+}
+
+tasks.matching {
+    val n = it.name.lowercase()
+    n.contains("forbidden") || n.contains("jandex") || n.contains("autostyle")
+}.configureEach { enabled = false }
+
+dependencies {
+    compileOnly("io.trino:trino-spi:$trinoVersion")
+
+    // Generic Calcite connector (CalciteClient) + the JDBC framework (transitively, via its api dep).
+    implementation(project(":trino-calcite"))
+
+    // The backing driver: org.apache.calcite.adapter.sharepoint.SharePointListDriver. Bundled.
+    implementation(project(":sharepoint-list"))
+
+    testImplementation("io.trino:trino-spi:$trinoVersion")
+    testImplementation("io.trino:trino-testing:$trinoVersion")
+    testImplementation("io.trino:trino-main:$trinoVersion")
+    // See trino-calcite: supply a JUnit Platform launcher matching trino-testing's JUnit 6.x.
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// See trino-calcite/build.gradle.kts for the plugin-directory packaging rationale.
+val trinoProvidedPrefixes = listOf("slice-", "jackson-annotations-", "opentelemetry-api-",
+        "opentelemetry-context-", "jol-core-")
+
+tasks.register<Zip>("trinoPlugin") {
+    group = "distribution"
+    description = "Builds the Trino plugin directory archive for the sharepoint connector."
+    archiveBaseName.set("trino-sharepoint-plugin")
+    into("trino-sharepoint") {
+        from(tasks.named("jar"))
+        from(configurations["runtimeClasspath"].filter { file ->
+            trinoProvidedPrefixes.none { file.name.startsWith(it) }
+        })
+    }
+}

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.sharepoint.trino;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+
+import org.apache.calcite.adapter.sharepoint.SharePointListDriver;
+import org.apache.calcite.adapter.trino.CalciteClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+/**
+ * Guice module for the SharePoint Trino connector. Reuses {@link CalciteClient} (the SharePoint
+ * lists are exposed over Calcite via standard JDBC types) and supplies a {@link ConnectionFactory}
+ * backed by {@code SharePointListDriver}.
+ *
+ * <p>The friendly catalog properties ({@code site-url}, {@code auth-type}, ...) from
+ * {@link SharePointConfig} are assembled into a {@code jdbc:sharepoint:} URL and installed as the
+ * {@link BaseJdbcConfig} {@code connection-url} default, so the user never supplies a raw URL.
+ */
+public class SharePointClientModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        SharePointConfig config = buildConfigObject(SharePointConfig.class);
+        String connectionUrl = buildConnectionUrl(config);
+        // Satisfy BaseJdbcConfig's mandatory connection-url (bound by the framework's JdbcModule)
+        // from the friendly SharePoint properties.
+        configBinder(binder).bindConfigDefaults(
+                BaseJdbcConfig.class, jdbcConfig -> jdbcConfig.setConnectionUrl(connectionUrl));
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
+                .to(CalciteClient.class).in(Scopes.SINGLETON);
+        // SharePoint list/column names are matched case-sensitively by Calcite, so the catalog
+        // should set case-insensitive-name-matching=true (see CalciteClientModule for details).
+    }
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory connectionFactory(
+            BaseJdbcConfig config,
+            CredentialProvider credentialProvider,
+            OpenTelemetry openTelemetry)
+    {
+        return DriverConnectionFactory.builder(
+                        new SharePointListDriver(),
+                        config.getConnectionUrl(),
+                        credentialProvider)
+                .setOpenTelemetry(openTelemetry)
+                .build();
+    }
+
+    /**
+     * Assembles a {@code jdbc:sharepoint:key=value;...} URL. Values are URL-encoded because
+     * {@code SharePointListDriver} URL-decodes each parameter value (and splits on {@code ;}).
+     */
+    private static String buildConnectionUrl(SharePointConfig config)
+    {
+        List<String> params = new ArrayList<>();
+        addParam(params, "siteUrl", config.getSiteUrl());
+        addParam(params, "authType", config.getAuthType());
+        addParam(params, "clientId", config.getClientId());
+        addParam(params, "clientSecret", config.getClientSecret());
+        addParam(params, "tenantId", config.getTenantId());
+        addParam(params, "user", config.getUser());
+        addParam(params, "password", config.getPassword());
+        return "jdbc:sharepoint:" + String.join(";", params);
+    }
+
+    private static void addParam(List<String> params, String key, String value)
+    {
+        if (value != null && !value.isEmpty()) {
+            params.add(key + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
@@ -103,6 +103,7 @@ public class SharePointClientModule
         addParam(params, "certificatePassword", config.getCertificatePassword());
         addParam(params, "thumbprint", config.getThumbprint());
         addParam(params, "schema", config.getSchema());
+        addParam(params, "metadataCacheTtl", config.getMetadataCacheTtl());
         return "jdbc:sharepoint:" + String.join(";", params);
     }
 

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
@@ -97,6 +97,10 @@ public class SharePointClientModule
         addParam(params, "tenantId", config.getTenantId());
         addParam(params, "user", config.getUser());
         addParam(params, "password", config.getPassword());
+        addParam(params, "certificatePath", config.getCertificatePath());
+        addParam(params, "certificatePassword", config.getCertificatePassword());
+        addParam(params, "thumbprint", config.getThumbprint());
+        addParam(params, "schema", config.getSchema());
         return "jdbc:sharepoint:" + String.join(";", params);
     }
 

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
@@ -31,6 +31,7 @@ import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 
 import org.apache.calcite.adapter.sharepoint.SharePointListDriver;
+import org.apache.calcite.adapter.trino.AutoCommitConnectionFactory;
 import org.apache.calcite.adapter.trino.CalciteClient;
 
 import java.net.URLEncoder;
@@ -75,12 +76,13 @@ public class SharePointClientModule
             CredentialProvider credentialProvider,
             OpenTelemetry openTelemetry)
     {
-        return DriverConnectionFactory.builder(
+        return new AutoCommitConnectionFactory(
+                DriverConnectionFactory.builder(
                         new SharePointListDriver(),
                         config.getConnectionUrl(),
                         credentialProvider)
                 .setOpenTelemetry(openTelemetry)
-                .build();
+                .build());
     }
 
     /**

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.sharepoint.trino;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Catalog configuration for the SharePoint Trino connector. These friendly properties are mapped
+ * onto a {@code jdbc:sharepoint:} URL for {@code SharePointListDriver}, so the user never writes a
+ * raw JDBC URL. Mirrors the parameters parsed by the SharePoint JDBC driver.
+ */
+public class SharePointConfig
+{
+    private String siteUrl;
+    private String authType;
+    private String clientId;
+    private String clientSecret;
+    private String tenantId;
+    private String user;
+    private String password;
+
+    @NotNull
+    public String getSiteUrl()
+    {
+        return siteUrl;
+    }
+
+    @Config("site-url")
+    @ConfigDescription("Full SharePoint site URL, e.g. https://contoso.sharepoint.com/sites/mysite")
+    public SharePointConfig setSiteUrl(String siteUrl)
+    {
+        this.siteUrl = siteUrl;
+        return this;
+    }
+
+    @NotNull
+    public String getAuthType()
+    {
+        return authType;
+    }
+
+    @Config("auth-type")
+    @ConfigDescription("CLIENT_CREDENTIALS, USERNAME_PASSWORD, DEVICE_CODE, MANAGED_IDENTITY or CERTIFICATE")
+    public SharePointConfig setAuthType(String authType)
+    {
+        this.authType = authType;
+        return this;
+    }
+
+    public String getClientId()
+    {
+        return clientId;
+    }
+
+    @Config("client-id")
+    @ConfigDescription("Azure AD app registration client ID")
+    public SharePointConfig setClientId(String clientId)
+    {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public String getClientSecret()
+    {
+        return clientSecret;
+    }
+
+    @Config("client-secret")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Client secret (CLIENT_CREDENTIALS auth)")
+    public SharePointConfig setClientSecret(String clientSecret)
+    {
+        this.clientSecret = clientSecret;
+        return this;
+    }
+
+    public String getTenantId()
+    {
+        return tenantId;
+    }
+
+    @Config("tenant-id")
+    @ConfigDescription("Azure AD tenant ID")
+    public SharePointConfig setTenantId(String tenantId)
+    {
+        this.tenantId = tenantId;
+        return this;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    @Config("user")
+    @ConfigDescription("User principal name (USERNAME_PASSWORD auth)")
+    public SharePointConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password (USERNAME_PASSWORD auth)")
+    public SharePointConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+}

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
@@ -40,6 +40,7 @@ public class SharePointConfig
     private String certificatePassword;
     private String thumbprint;
     private String schema;
+    private String metadataCacheTtl;
 
     @NotNull
     public String getSiteUrl()
@@ -186,6 +187,19 @@ public class SharePointConfig
     public SharePointConfig setSchema(String schema)
     {
         this.schema = schema;
+        return this;
+    }
+
+    public String getMetadataCacheTtl()
+    {
+        return metadataCacheTtl;
+    }
+
+    @Config("metadata-cache-ttl")
+    @ConfigDescription("List-discovery cache TTL in seconds (default 300; -1 = never expire, 0 = disabled)")
+    public SharePointConfig setMetadataCacheTtl(String metadataCacheTtl)
+    {
+        this.metadataCacheTtl = metadataCacheTtl;
         return this;
     }
 }

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointConfig.java
@@ -36,6 +36,10 @@ public class SharePointConfig
     private String tenantId;
     private String user;
     private String password;
+    private String certificatePath;
+    private String certificatePassword;
+    private String thumbprint;
+    private String schema;
 
     @NotNull
     public String getSiteUrl()
@@ -129,6 +133,59 @@ public class SharePointConfig
     public SharePointConfig setPassword(String password)
     {
         this.password = password;
+        return this;
+    }
+
+    public String getCertificatePath()
+    {
+        return certificatePath;
+    }
+
+    @Config("certificate-path")
+    @ConfigDescription("Path to the PKCS#12 (.pfx) certificate file (CERTIFICATE auth)")
+    public SharePointConfig setCertificatePath(String certificatePath)
+    {
+        this.certificatePath = certificatePath;
+        return this;
+    }
+
+    public String getCertificatePassword()
+    {
+        return certificatePassword;
+    }
+
+    @Config("certificate-password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Password for the PKCS#12 certificate (CERTIFICATE auth)")
+    public SharePointConfig setCertificatePassword(String certificatePassword)
+    {
+        this.certificatePassword = certificatePassword;
+        return this;
+    }
+
+    public String getThumbprint()
+    {
+        return thumbprint;
+    }
+
+    @Config("thumbprint")
+    @ConfigDescription("Optional certificate SHA-1 thumbprint; omit to auto-compute from the .pfx")
+    public SharePointConfig setThumbprint(String thumbprint)
+    {
+        this.thumbprint = thumbprint;
+        return this;
+    }
+
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @Config("schema")
+    @ConfigDescription("Schema name exposed for the SharePoint lists (default: sharepoint)")
+    public SharePointConfig setSchema(String schema)
+    {
+        this.schema = schema;
         return this;
     }
 }

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointPlugin.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.sharepoint.trino;
+
+import io.trino.plugin.jdbc.JdbcPlugin;
+
+/**
+ * Trino plugin exposing SharePoint Lists as a SQL catalog. Wraps the generic Calcite connector
+ * with a SharePoint-specific connection factory and friendly catalog properties.
+ *
+ * <p>The connector is named {@code sharepoint}; configure a catalog with
+ * {@code connector.name=sharepoint} plus {@code site-url}, {@code auth-type} and the relevant
+ * credential properties (see {@link SharePointConfig}).
+ */
+public class SharePointPlugin
+        extends JdbcPlugin
+{
+    public SharePointPlugin()
+    {
+        super("sharepoint", SharePointClientModule::new);
+    }
+}

--- a/trino-sharepoint/src/main/resources/META-INF/services/io.trino.spi.Plugin
+++ b/trino-sharepoint/src/main/resources/META-INF/services/io.trino.spi.Plugin
@@ -1,0 +1,1 @@
+org.apache.calcite.adapter.sharepoint.trino.SharePointPlugin

--- a/trino-splunk/README.md
+++ b/trino-splunk/README.md
@@ -1,0 +1,73 @@
+# Trino Splunk Connector
+
+A [Trino](https://trino.io) connector that exposes Splunk (its CIM data models, indexes and custom
+tables) as a SQL catalog. It is a thin wrapper over the generic
+[trino-calcite](../trino-calcite) connector: it reuses `CalciteClient` for type mapping and only
+swaps in the Splunk JDBC driver (`org.apache.calcite.adapter.splunk.SplunkDriver`) plus friendly
+catalog properties, so users never write a raw JDBC URL.
+
+## Requirements
+
+Like any Trino plugin, it must be built against the exact SPI version of the target server — the
+version pinned by `trino.version` in the repo's `gradle.properties` (currently **481**, **Java 25**).
+
+## Build & install
+
+```bash
+./gradlew :trino-splunk:trinoPlugin
+unzip trino-splunk/build/distributions/trino-splunk-plugin-*.zip -d "$TRINO_HOME/plugin/"
+```
+
+## Configure a catalog
+
+Create `etc/catalog/splunk.properties`:
+
+```properties
+connector.name=splunk
+url=https://localhost:8089
+# Authenticate with a token (preferred) ...
+token=eyJhbGciOiJIUzI1NiI...
+# ... or with user + password:
+# user=admin
+# password=changeme
+# Optional: app context + data-model discovery filter
+app=Splunk_SA_CIM
+datamodel-filter=Authentication
+# Splunk schemas/tables are matched case-sensitively by Calcite; keep this on.
+case-insensitive-name-matching=true
+```
+
+| Property | Description | Required |
+|----------|-------------|----------|
+| `url` | Splunk management URL, e.g. `https://localhost:8089` | Yes |
+| `token` | Splunk auth token (preferred) | Conditional |
+| `user` / `password` | Username + password (when not using a token) | Conditional |
+| `app` | App context for data-model discovery (e.g. `Splunk_SA_CIM`) | No |
+| `datamodel-filter` | Data-model discovery filter (name, glob, or `/regex/`) | No |
+| `disable-ssl-validation` | Disable TLS validation (test/self-signed only) | No |
+
+These map onto a `jdbc:splunk:url=…;token=…` URL for `SplunkDriver`; see the
+[splunk adapter](../splunk) for the full set of supported connection parameters (CIM models, custom
+tables, cache control, environment-variable fallback, etc.).
+
+## Example queries
+
+```sql
+SHOW TABLES FROM splunk.splunk;
+SELECT _time, action, src_ip FROM splunk.splunk.authentication
+WHERE _time > CURRENT_TIMESTAMP - INTERVAL '1' HOUR;
+```
+
+## Behaviour and limitations
+
+- **Pushdown.** Same as [trino-calcite](../trino-calcite) (it *is* that connector under the hood):
+  Trino pushes projection and simple predicate filters down to the Calcite JDBC source. How those
+  are executed below Calcite — including the Splunk adapter's own search pushdown — is internal to
+  that adapter, not the connector.
+- Authentication, data-model discovery and SSL handling are owned by the underlying Splunk adapter.
+
+## Testing
+
+A live Splunk instance (or recorded backend) is required for an end-to-end test; tag such tests as
+integration-only. The generic Trino↔Calcite path is covered by
+[trino-calcite](../trino-calcite)'s in-process test.

--- a/trino-splunk/build.gradle.kts
+++ b/trino-splunk/build.gradle.kts
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Trino connector for Splunk. A thin wrapper over the generic trino-calcite connector: it reuses
+// CalciteClient for type mapping and only swaps in the Splunk JDBC driver plus friendly catalog
+// properties (url, token, user/password, app, ...). See trino-calcite for the toolchain rationale.
+
+val trinoVersion = providers.gradleProperty("trino.version").get()
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(25)
+}
+
+tasks.matching {
+    val n = it.name.lowercase()
+    n.contains("forbidden") || n.contains("jandex") || n.contains("autostyle")
+}.configureEach { enabled = false }
+
+dependencies {
+    compileOnly("io.trino:trino-spi:$trinoVersion")
+
+    // Generic Calcite connector (CalciteClient) + the JDBC framework (transitively, via its api dep).
+    implementation(project(":trino-calcite"))
+
+    // The backing driver: org.apache.calcite.adapter.splunk.SplunkDriver. Bundled.
+    implementation(project(":splunk"))
+
+    testImplementation("io.trino:trino-spi:$trinoVersion")
+    testImplementation("io.trino:trino-testing:$trinoVersion")
+    testImplementation("io.trino:trino-main:$trinoVersion")
+    // See trino-calcite: supply a JUnit Platform launcher matching trino-testing's JUnit 6.x.
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+// See trino-calcite/build.gradle.kts for the plugin-directory packaging rationale.
+val trinoProvidedPrefixes = listOf("slice-", "jackson-annotations-", "opentelemetry-api-",
+        "opentelemetry-context-", "jol-core-")
+
+tasks.register<Zip>("trinoPlugin") {
+    group = "distribution"
+    description = "Builds the Trino plugin directory archive for the splunk connector."
+    archiveBaseName.set("trino-splunk-plugin")
+    into("trino-splunk") {
+        from(tasks.named("jar"))
+        from(configurations["runtimeClasspath"].filter { file ->
+            trinoProvidedPrefixes.none { file.name.startsWith(it) }
+        })
+    }
+}

--- a/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkClientModule.java
+++ b/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkClientModule.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.splunk.trino;
+
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.jdbc.BaseJdbcConfig;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForBaseJdbc;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.credential.CredentialProvider;
+
+import org.apache.calcite.adapter.splunk.SplunkDriver;
+import org.apache.calcite.adapter.trino.CalciteClient;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+/**
+ * Guice module for the Splunk Trino connector. Reuses {@link CalciteClient} (Splunk is exposed over
+ * Calcite via standard JDBC types) and supplies a {@link ConnectionFactory} backed by
+ * {@code SplunkDriver}.
+ *
+ * <p>The friendly catalog properties ({@code url}, {@code token}, ...) from {@link SplunkConfig} are
+ * assembled into a {@code jdbc:splunk:} URL and installed as the {@link BaseJdbcConfig}
+ * {@code connection-url} default, so the user never supplies a raw URL.
+ */
+public class SplunkClientModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        SplunkConfig config = buildConfigObject(SplunkConfig.class);
+        String connectionUrl = buildConnectionUrl(config);
+        // Satisfy BaseJdbcConfig's mandatory connection-url (bound by the framework's JdbcModule)
+        // from the friendly Splunk properties.
+        configBinder(binder).bindConfigDefaults(
+                BaseJdbcConfig.class, jdbcConfig -> jdbcConfig.setConnectionUrl(connectionUrl));
+        binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
+                .to(CalciteClient.class).in(Scopes.SINGLETON);
+        // Splunk schemas/tables are matched case-sensitively by Calcite, so the catalog should set
+        // case-insensitive-name-matching=true (see CalciteClientModule for details).
+    }
+
+    @Provides
+    @Singleton
+    @ForBaseJdbc
+    public static ConnectionFactory connectionFactory(
+            BaseJdbcConfig config,
+            CredentialProvider credentialProvider,
+            OpenTelemetry openTelemetry)
+    {
+        return DriverConnectionFactory.builder(
+                        new SplunkDriver(),
+                        config.getConnectionUrl(),
+                        credentialProvider)
+                .setOpenTelemetry(openTelemetry)
+                .build();
+    }
+
+    /**
+     * Assembles a {@code jdbc:splunk:key=value;...} URL. Values are URL-encoded because
+     * {@code SplunkDriver} URL-decodes each parameter value (and splits on {@code ;}).
+     */
+    private static String buildConnectionUrl(SplunkConfig config)
+    {
+        List<String> params = new ArrayList<>();
+        addParam(params, "url", config.getUrl());
+        addParam(params, "token", config.getToken());
+        addParam(params, "user", config.getUser());
+        addParam(params, "password", config.getPassword());
+        addParam(params, "app", config.getApp());
+        addParam(params, "datamodelFilter", config.getDatamodelFilter());
+        if (config.isDisableSslValidation()) {
+            params.add("disableSslValidation=true");
+        }
+        return "jdbc:splunk:" + String.join(";", params);
+    }
+
+    private static void addParam(List<String> params, String key, String value)
+    {
+        if (value != null && !value.isEmpty()) {
+            params.add(key + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkConfig.java
+++ b/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkConfig.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.splunk.trino;
+
+import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigSecuritySensitive;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Catalog configuration for the Splunk Trino connector. These friendly properties are mapped onto a
+ * {@code jdbc:splunk:} URL for {@code SplunkDriver}, so the user never writes a raw JDBC URL.
+ * Authenticate with either {@code token} or {@code user} + {@code password}.
+ */
+public class SplunkConfig
+{
+    private String url;
+    private String token;
+    private String user;
+    private String password;
+    private String app;
+    private String datamodelFilter;
+    private boolean disableSslValidation;
+
+    @NotNull
+    public String getUrl()
+    {
+        return url;
+    }
+
+    @Config("url")
+    @ConfigDescription("Splunk management URL, e.g. https://localhost:8089")
+    public SplunkConfig setUrl(String url)
+    {
+        this.url = url;
+        return this;
+    }
+
+    public String getToken()
+    {
+        return token;
+    }
+
+    @Config("token")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Splunk authentication token (preferred over user/password)")
+    public SplunkConfig setToken(String token)
+    {
+        this.token = token;
+        return this;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    @Config("user")
+    @ConfigDescription("Splunk username (when not using a token)")
+    public SplunkConfig setUser(String user)
+    {
+        this.user = user;
+        return this;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    @Config("password")
+    @ConfigSecuritySensitive
+    @ConfigDescription("Splunk password (when not using a token)")
+    public SplunkConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    public String getApp()
+    {
+        return app;
+    }
+
+    @Config("app")
+    @ConfigDescription("Splunk app context for data model discovery, e.g. Splunk_SA_CIM")
+    public SplunkConfig setApp(String app)
+    {
+        this.app = app;
+        return this;
+    }
+
+    public String getDatamodelFilter()
+    {
+        return datamodelFilter;
+    }
+
+    @Config("datamodel-filter")
+    @ConfigDescription("Filter for data model discovery (name, glob, or /regex/)")
+    public SplunkConfig setDatamodelFilter(String datamodelFilter)
+    {
+        this.datamodelFilter = datamodelFilter;
+        return this;
+    }
+
+    public boolean isDisableSslValidation()
+    {
+        return disableSslValidation;
+    }
+
+    @Config("disable-ssl-validation")
+    @ConfigDescription("Disable TLS certificate validation (test/self-signed servers only)")
+    public SplunkConfig setDisableSslValidation(boolean disableSslValidation)
+    {
+        this.disableSslValidation = disableSslValidation;
+        return this;
+    }
+}

--- a/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkPlugin.java
+++ b/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.splunk.trino;
+
+import io.trino.plugin.jdbc.JdbcPlugin;
+
+/**
+ * Trino plugin exposing Splunk as a SQL catalog. Wraps the generic Calcite connector with a
+ * Splunk-specific connection factory and friendly catalog properties.
+ *
+ * <p>The connector is named {@code splunk}; configure a catalog with {@code connector.name=splunk}
+ * plus {@code url} and either {@code token} or {@code user}/{@code password} (see
+ * {@link SplunkConfig}).
+ */
+public class SplunkPlugin
+        extends JdbcPlugin
+{
+    public SplunkPlugin()
+    {
+        super("splunk", SplunkClientModule::new);
+    }
+}

--- a/trino-splunk/src/main/resources/META-INF/services/io.trino.spi.Plugin
+++ b/trino-splunk/src/main/resources/META-INF/services/io.trino.spi.Plugin
@@ -1,0 +1,1 @@
+org.apache.calcite.adapter.splunk.trino.SplunkPlugin


### PR DESCRIPTION
## Summary

Adds **Trino connectors** for the Calcite-based JDBC adapters and fixes the underlying JDBC drivers so they actually work end-to-end.

### New: Trino connectors (`trino-base-jdbc` plugins)
- **`trino-calcite`** — generic connector over any Calcite model (`jdbc:calcite:`); shared `CalciteClient` type mapping. In-process integration test included.
- **`trino-sharepoint`** — SharePoint Lists as a SQL catalog (friendly catalog properties; cert/secret/user auth, `schema`, `metadata-cache-ttl`).
- **`trino-splunk`** — Splunk as a SQL catalog.
- **`.github/workflows/trino-connectors.yml`** — builds the plugin-directory archives (Java 25 toolchain, Gradle on Java 21) as artifacts + release assets.

### JDBC driver fixes (these were returning `null` / failing)
- **Driver delegation** (`SharePointListDriver`, `CloudOpsDriver`, `AperioDriver`): delegated to a plain Calcite driver instead of `super.connect("jdbc:calcite:")`, which the inherited `acceptsURL()` rejected (drivers always returned null → "No suitable driver found"). Matches the existing `GovDataDriver` fix.
- **SharePoint certificate auth**: `x5t` thumbprint moved to the JWT **header** (Azure `AADSTS5002723`), and JJWT pinned to the plugin classloader (Trino `ClassCastException`).

### SharePoint adapter improvements
- Process-wide **list-discovery cache** (TTL) — stops re-crawling the whole site on every connection (killed Graph throttling under Trino).
- Complex column values coerced to **JSON**; `TIMESTAMP` read/written as Calcite epoch-millis (fixes calendar reads/writes).
- **Write-gating by list template** (libraries/surveys read-only; generic/tasks/calendars writable).
- Configurable **schema** name; `CREATE TABLE` can make **calendars/task lists** via a `__template` sentinel column.

### Trino write-back
- `AutoCommitConnectionFactory` presents a non-transactional connection (autoCommit=true, no-op commit/rollback) so Trino `INSERT` works against the non-transactional adapters.

## Verification (real services, Docker)
- **SharePoint** (Trino 481, live site, certificate auth): catalog loads, **55/55 lists read** (calendars/libraries included), `INSERT` works via JDBC **and** Trino, calendar events written with correct dates.
- **Splunk** (`splunk/splunk`): catalog loads, tables discovered, real rows read.

## Notes
- Trino plugins are version-locked to the server SPI; pinned to `trino.version=481` (Java 25). The connector modules use their own toolchain; the Java 8 adapters are unchanged.
