### PR TITLE
docs(trino): download/install/configure instructions in connector READMEs

### DIFF
--- a/trino-calcite/README.md
+++ b/trino-calcite/README.md
@@ -12,7 +12,22 @@ This module targets the version pinned by `trino.version` in the repo's `gradle.
 (currently **481**, which requires **Java 25**). The module builds with its own Java 25 toolchain;
 the Calcite driver it bundles is Java 8 bytecode and runs unchanged on the Trino JVM.
 
+## Download
+
+Prebuilt plugin archives are attached to each `trino-v*` GitHub release. Grab
+`trino-calcite-plugin-<version>.zip` from the
+[Releases page](https://github.com/kenstott/calcite/releases), or with the GitHub CLI:
+
+```bash
+gh release download <trino-vX.Y.Z> --repo kenstott/calcite --pattern 'trino-calcite-plugin-*.zip'
+```
+
+The `Trino Connectors` workflow also publishes the archives as a `trino-connector-packages`
+build artifact on each run.
+
 ## Build
+
+Or build the archive from source:
 
 ```bash
 ./gradlew :trino-calcite:trinoPlugin

--- a/trino-sharepoint/README.md
+++ b/trino-sharepoint/README.md
@@ -11,11 +11,28 @@ friendly catalog properties so you never write a raw JDBC URL.
 A Trino plugin must be built against the exact SPI version of the target server — the version pinned
 by `trino.version` in the repo's `gradle.properties` (currently **481**, which requires **Java 25**).
 
-## Build & install
+## Download
+
+Prebuilt plugin archives are attached to each `trino-v*` GitHub release. Grab
+`trino-sharepoint-plugin-<version>.zip` from the
+[Releases page](https://github.com/kenstott/calcite/releases), or with the GitHub CLI:
 
 ```bash
+gh release download <trino-vX.Y.Z> --repo kenstott/calcite --pattern 'trino-sharepoint-plugin-*.zip'
+```
+
+The `Trino Connectors` workflow also publishes the archives as a `trino-connector-packages`
+build artifact on each run.
+
+## Build & install
+
+Install the downloaded archive (or build from source) into the Trino server's `plugin/` directory,
+then restart Trino:
+
+```bash
+# build from source (optional)
 ./gradlew :trino-sharepoint:trinoPlugin
-# Output: trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip
+# install
 unzip trino-sharepoint/build/distributions/trino-sharepoint-plugin-*.zip -d "$TRINO_HOME/plugin/"
 # yields $TRINO_HOME/plugin/trino-sharepoint/<jars>; restart Trino
 ```

--- a/trino-splunk/README.md
+++ b/trino-splunk/README.md
@@ -11,11 +11,30 @@ catalog properties, so users never write a raw JDBC URL.
 Like any Trino plugin, it must be built against the exact SPI version of the target server — the
 version pinned by `trino.version` in the repo's `gradle.properties` (currently **481**, **Java 25**).
 
-## Build & install
+## Download
+
+Prebuilt plugin archives are attached to each `trino-v*` GitHub release. Grab
+`trino-splunk-plugin-<version>.zip` from the
+[Releases page](https://github.com/kenstott/calcite/releases), or with the GitHub CLI:
 
 ```bash
+gh release download <trino-vX.Y.Z> --repo kenstott/calcite --pattern 'trino-splunk-plugin-*.zip'
+```
+
+The `Trino Connectors` workflow also publishes the archives as a `trino-connector-packages`
+build artifact on each run.
+
+## Build & install
+
+Install the downloaded archive (or build from source) into the Trino server's `plugin/` directory,
+then restart Trino:
+
+```bash
+# build from source (optional)
 ./gradlew :trino-splunk:trinoPlugin
+# install
 unzip trino-splunk/build/distributions/trino-splunk-plugin-*.zip -d "$TRINO_HOME/plugin/"
+# yields $TRINO_HOME/plugin/trino-splunk/<jars>; restart Trino
 ```
 
 ## Configure a catalog


### PR DESCRIPTION
Adds a **Download** section to each Trino connector README (trino-calcite, trino-sharepoint, trino-splunk) explaining how to get the prebuilt `trino-<connector>-plugin-<version>.zip` from the `trino-v*` GitHub release (or the `trino-connector-packages` Actions artifact), plus install and catalog-configuration steps. Building from source remains documented as the alternative.