### PR TITLE
fix(trino): fail fast when case-insensitive-name-matching is unset

### DIFF
--- a/trino-calcite-base/src/main/java/org/apache/calcite/adapter/trino/CalciteConnectorConfig.java
+++ b/trino-calcite-base/src/main/java/org/apache/calcite/adapter/trino/CalciteConnectorConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.trino;
+
+import io.trino.plugin.base.mapping.MappingConfig;
+
+/**
+ * Shared configuration guards for the Calcite-backed Trino connectors.
+ */
+public final class CalciteConnectorConfig
+{
+    private CalciteConnectorConfig() {}
+
+    /**
+     * Fail catalog creation unless {@code case-insensitive-name-matching=true} is set.
+     *
+     * <p>Calcite matches identifiers case-sensitively (as declared in the model, typically
+     * lower-case) while its Avatica metadata reports {@code storesUpperCaseIdentifiers()==true}.
+     * Without case-insensitive matching, Trino upper-cases requested names and resolves none of an
+     * adapter's tables: {@code listTables()} still enumerates them, but {@code getTableHandle} fails
+     * with {@code TABLE_NOT_FOUND} and {@code information_schema.columns} returns no user columns.
+     *
+     * <p>The flag cannot be defaulted in code because the JDBC framework reads it at module-setup
+     * time (in {@code IdentifierMappingModule}) to decide whether to install the caching identifier
+     * mapping. Adapter-backed connectors (SharePoint, CloudOps, File, Splunk) generate their own
+     * lower-case names, so the flag is effectively mandatory and we fail fast with an actionable
+     * message. The generic {@code calcite} connector lets the model author control casing, so it
+     * documents the flag instead of requiring it.
+     *
+     * @param enabled value of {@code MappingConfig.isCaseInsensitiveNameMatching()} for the catalog
+     * @param connector human-readable connector name for the error message (e.g. {@code "SharePoint"})
+     */
+    public static void requireCaseInsensitiveNameMatching(boolean enabled, String connector)
+    {
+        if (!enabled) {
+            throw new IllegalStateException(
+                    "The " + connector + " connector requires '"
+                            + MappingConfig.CASE_INSENSITIVE_NAME_MATCHING + "=true' in the catalog "
+                            + "properties. Calcite matches identifiers case-sensitively while reporting "
+                            + "upper-case storage, so without it tables are listed but cannot be queried "
+                            + "(DESCRIBE/SELECT fail with TABLE_NOT_FOUND and information_schema.columns "
+                            + "is empty). Add '" + MappingConfig.CASE_INSENSITIVE_NAME_MATCHING
+                            + "=true' to etc/catalog/<catalog>.properties and restart Trino.");
+        }
+    }
+}

--- a/trino-cloudops/README.md
+++ b/trino-cloudops/README.md
@@ -19,6 +19,7 @@ configured provider **fails fast at startup** with a list of the missing propert
 
 ```properties
 connector.name=cloudops
+case-insensitive-name-matching=true
 
 # AWS
 aws.access-key-id=AKIA...
@@ -33,8 +34,15 @@ azure.client-secret=...
 azure.subscription-ids=sub-1,sub-2
 ```
 
+> **`case-insensitive-name-matching=true` is required.** CloudOps table/column names are generated
+> lower-case, but Calcite's Avatica metadata reports `storesUpperCaseIdentifiers()=true`; without
+> this flag Trino upper-cases names and resolves no tables (`DESCRIBE`/`SELECT` fail with
+> `TABLE_NOT_FOUND` and `information_schema.columns` is empty). The connector **fails fast at
+> startup** if it is not set.
+
 | Property | Required | Description |
 |----------|----------|-------------|
+| `case-insensitive-name-matching` | yes | Must be `true` — see note above |
 | `providers` | no | Comma-separated subset to query, e.g. `azure,aws` (default: all configured) |
 | `azure.tenant-id` | enables Azure | Azure AD tenant ID |
 | `azure.client-id` | with Azure | App registration client ID |

--- a/trino-cloudops/src/main/java/org/apache/calcite/adapter/ops/trino/CloudOpsClientModule.java
+++ b/trino-cloudops/src/main/java/org/apache/calcite/adapter/ops/trino/CloudOpsClientModule.java
@@ -23,6 +23,7 @@ import com.google.inject.Singleton;
 
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.base.mapping.MappingConfig;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
@@ -33,6 +34,7 @@ import io.trino.plugin.jdbc.credential.CredentialProvider;
 import org.apache.calcite.adapter.ops.CloudOpsDriver;
 import org.apache.calcite.adapter.trino.AutoCommitConnectionFactory;
 import org.apache.calcite.adapter.trino.CalciteClient;
+import org.apache.calcite.adapter.trino.CalciteConnectorConfig;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -65,8 +67,10 @@ public class CloudOpsClientModule
                 BaseJdbcConfig.class, jdbcConfig -> jdbcConfig.setConnectionUrl(connectionUrl));
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
                 .to(CalciteClient.class).in(Scopes.SINGLETON);
-        // CloudOps table/column names are matched case-sensitively by Calcite, so the catalog should
-        // set case-insensitive-name-matching=true (see CalciteClientModule for details).
+        // CloudOps table/column names are generated lower-case, so case-insensitive name matching is
+        // mandatory; fail fast with an actionable message otherwise (see CalciteConnectorConfig).
+        CalciteConnectorConfig.requireCaseInsensitiveNameMatching(
+                buildConfigObject(MappingConfig.class).isCaseInsensitiveNameMatching(), "CloudOps");
     }
 
     @Provides

--- a/trino-file/README.md
+++ b/trino-file/README.md
@@ -15,11 +15,19 @@ are assembled into an inline Calcite model (`jdbc:calcite:model=inline:{…}`) t
 
 ```properties
 connector.name=file
+case-insensitive-name-matching=true
 glob=s3://my-bucket/data/**/*.parquet
 ```
 
+> **`case-insensitive-name-matching=true` is required.** File table/column names are generated
+> lower-case, but Calcite's Avatica metadata reports `storesUpperCaseIdentifiers()=true`; without
+> this flag Trino upper-cases names and resolves no tables (`DESCRIBE`/`SELECT` fail with
+> `TABLE_NOT_FOUND` and `information_schema.columns` is empty). The connector **fails fast at
+> startup** if it is not set.
+
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
+| `case-insensitive-name-matching` | yes | — | Must be `true` — see note above |
 | `glob` | yes | — | A local path or a remote URI glob (see Storage backends) |
 | `schema-name` | no | `files` | Trino schema name exposed |
 | `execution-engine` | no | `DUCKDB` | File-adapter engine: `DUCKDB`, `PARQUET`, `LINQ4J`, `ARROW`. DuckDB reads CSV/Parquet natively without Hadoop; PARQUET converts via Hadoop (incompatible with JDK 25 — see below) |

--- a/trino-file/src/main/java/org/apache/calcite/adapter/file/trino/FileClientModule.java
+++ b/trino-file/src/main/java/org/apache/calcite/adapter/file/trino/FileClientModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Singleton;
 
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.base.mapping.MappingConfig;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
@@ -35,6 +36,7 @@ import io.trino.plugin.jdbc.credential.CredentialProvider;
 
 import org.apache.calcite.adapter.trino.AutoCommitConnectionFactory;
 import org.apache.calcite.adapter.trino.CalciteClient;
+import org.apache.calcite.adapter.trino.CalciteConnectorConfig;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -82,8 +84,10 @@ public class FileClientModule
         });
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
                 .to(CalciteClient.class).in(Scopes.SINGLETON);
-        // File table/column names are matched case-sensitively by Calcite, so the catalog should
-        // set case-insensitive-name-matching=true (see CalciteClientModule for details).
+        // File table/column names are generated lower-case, so case-insensitive name matching is
+        // mandatory; fail fast with an actionable message otherwise (see CalciteConnectorConfig).
+        CalciteConnectorConfig.requireCaseInsensitiveNameMatching(
+                buildConfigObject(MappingConfig.class).isCaseInsensitiveNameMatching(), "File");
     }
 
     @Provides

--- a/trino-file/src/test/java/org/apache/calcite/adapter/file/trino/TestFileConnector.java
+++ b/trino-file/src/test/java/org/apache/calcite/adapter/file/trino/TestFileConnector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.calcite.adapter.file.trino;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 
 import io.trino.Session;
@@ -31,6 +32,7 @@ import java.nio.file.Paths;
 
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -72,6 +74,25 @@ class TestFileConnector
         MaterializedResult tables = computeActual("SHOW TABLES FROM file.files");
         assertTrue(tables.getOnlyColumnAsSet().contains("events"),
                 "expected 'events' table, got: " + tables.getOnlyColumnAsSet());
+    }
+
+    @Test
+    void testMissingCaseInsensitiveNameMatchingFailsFast()
+            throws Exception
+    {
+        // Without case-insensitive-name-matching the adapter's lower-case tables are unresolvable
+        // (issues #221/#222). The connector must fail fast at catalog creation with an actionable
+        // message rather than silently serving an empty catalog.
+        String dir = Paths.get(getClass().getResource("/files").toURI()).toString();
+        try (QueryRunner runner = DistributedQueryRunner.builder(
+                testSessionBuilder().setCatalog("file_no_flag").setSchema("files").build()).build()) {
+            runner.installPlugin(new FilePlugin());
+            RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                    runner.createCatalog("file_no_flag", "file", ImmutableMap.of("glob", dir)));
+            assertTrue(
+                    Throwables.getStackTraceAsString(thrown).contains("case-insensitive-name-matching"),
+                    "expected an actionable case-insensitive-name-matching error, got: " + thrown);
+        }
     }
 
     @Test

--- a/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
+++ b/trino-sharepoint/src/main/java/org/apache/calcite/adapter/sharepoint/trino/SharePointClientModule.java
@@ -23,6 +23,7 @@ import com.google.inject.Singleton;
 
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.base.mapping.MappingConfig;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
@@ -33,6 +34,7 @@ import io.trino.plugin.jdbc.credential.CredentialProvider;
 import org.apache.calcite.adapter.sharepoint.SharePointListDriver;
 import org.apache.calcite.adapter.trino.AutoCommitConnectionFactory;
 import org.apache.calcite.adapter.trino.CalciteClient;
+import org.apache.calcite.adapter.trino.CalciteConnectorConfig;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -57,6 +59,10 @@ public class SharePointClientModule
     protected void setup(Binder binder)
     {
         SharePointConfig config = buildConfigObject(SharePointConfig.class);
+        // SharePoint list/column names are generated lower-case, so case-insensitive name matching is
+        // mandatory; fail fast with an actionable message otherwise (see CalciteConnectorConfig).
+        CalciteConnectorConfig.requireCaseInsensitiveNameMatching(
+                buildConfigObject(MappingConfig.class).isCaseInsensitiveNameMatching(), "SharePoint");
         String connectionUrl = buildConnectionUrl(config);
         // Satisfy BaseJdbcConfig's mandatory connection-url (bound by the framework's JdbcModule)
         // from the friendly SharePoint properties.

--- a/trino-splunk/README.md
+++ b/trino-splunk/README.md
@@ -52,13 +52,15 @@ token=eyJhbGciOiJIUzI1NiI...
 # Optional: app context + data-model discovery filter
 app=Splunk_SA_CIM
 datamodel-filter=Authentication
-# Splunk schemas/tables are matched case-sensitively by Calcite; keep this on.
+# Required: Splunk names are generated lower-case but Calcite reports upper-case storage;
+# the connector fails fast at startup without this. Keep it on.
 case-insensitive-name-matching=true
 ```
 
 | Property | Description | Required |
 |----------|-------------|----------|
 | `url` | Splunk management URL, e.g. `https://localhost:8089` | Yes |
+| `case-insensitive-name-matching` | Must be `true` — see note above | Yes |
 | `token` | Splunk auth token (preferred) | Conditional |
 | `user` / `password` | Username + password (when not using a token) | Conditional |
 | `app` | App context for data-model discovery (e.g. `Splunk_SA_CIM`) | No |

--- a/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkClientModule.java
+++ b/trino-splunk/src/main/java/org/apache/calcite/adapter/splunk/trino/SplunkClientModule.java
@@ -23,6 +23,7 @@ import com.google.inject.Singleton;
 
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.opentelemetry.api.OpenTelemetry;
+import io.trino.plugin.base.mapping.MappingConfig;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
@@ -32,6 +33,7 @@ import io.trino.plugin.jdbc.credential.CredentialProvider;
 
 import org.apache.calcite.adapter.splunk.SplunkDriver;
 import org.apache.calcite.adapter.trino.CalciteClient;
+import org.apache.calcite.adapter.trino.CalciteConnectorConfig;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -63,8 +65,10 @@ public class SplunkClientModule
                 BaseJdbcConfig.class, jdbcConfig -> jdbcConfig.setConnectionUrl(connectionUrl));
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class)
                 .to(CalciteClient.class).in(Scopes.SINGLETON);
-        // Splunk schemas/tables are matched case-sensitively by Calcite, so the catalog should set
-        // case-insensitive-name-matching=true (see CalciteClientModule for details).
+        // Splunk schema/table names are generated lower-case, so case-insensitive name matching is
+        // mandatory; fail fast with an actionable message otherwise (see CalciteConnectorConfig).
+        CalciteConnectorConfig.requireCaseInsensitiveNameMatching(
+                buildConfigObject(MappingConfig.class).isCaseInsensitiveNameMatching(), "Splunk");
     }
 
     @Provides


### PR DESCRIPTION
Resolves #221 and #222.

## Problem
The Calcite-backed Trino connectors enumerate adapter tables via `listTables()` but cannot resolve them unless the catalog sets `case-insensitive-name-matching=true`. Calcite matches identifiers case-sensitively (lower-case) while its Avatica metadata reports `storesUpperCaseIdentifiers()=true`, so Trino upper-cases requested names and:
- `getTableHandle` returns `TABLE_NOT_FOUND` for every list (#222)
- `information_schema.columns` returns no user columns (#221)

## Fix
The flag cannot be defaulted in code (the JDBC framework reads it at module-setup time to decide whether to install the caching identifier mapping). Instead of failing silently, a shared `CalciteConnectorConfig` guard fails catalog creation with an actionable message, wired into the four adapter-backed connectors (sharepoint, cloudops, file, splunk) whose names are always generated lower-case. The generic `calcite` connector is left documented-only since the model author controls casing.

Also documents the required property in the cloudops/file/splunk READMEs and adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)