### PR TITLE
fix(release): dispatch pgwire releases with --repo and actions:write

### DIFF
--- a/.github/workflows/askamerica-engine.yml
+++ b/.github/workflows/askamerica-engine.yml
@@ -628,6 +628,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      actions: write   # needed to dispatch the pgwire release workflows below
 
     steps:
       - name: Download JAR
@@ -728,6 +729,6 @@ jobs:
         run: |
           BARE="${{ github.ref_name }}"
           BARE="${BARE#engine-v}"
-          gh workflow run "pgwire-calcite release" --ref main --field version="${BARE}"
-          gh workflow run "pgwire-adapters release" --ref main --field version="${BARE}"
+          gh workflow run "pgwire-calcite release" --repo "${{ github.repository }}" --ref main --field version="${BARE}"
+          gh workflow run "pgwire-adapters release" --repo "${{ github.repository }}" --ref main --field version="${BARE}"
           echo "Dispatched pgwire-calcite + pgwire-adapters releases for version ${BARE}"


### PR DESCRIPTION
## Why 0.28.0 shipped without pgwire artifacts

The `release` job in `askamerica-engine.yml` dispatches the two pgwire release
workflows as its final step, but it never checks out the repo. `gh workflow run`
therefore failed with `fatal: not a git repository` and the pgwire workflows were
never triggered — so engine-v0.28.0 has no `pgwire-*` assets.

## Fix
- Pass `--repo ${{ github.repository }}` to both `gh workflow run` calls (matches the dispatch calls in `release-please.yml`).
- Grant `actions: write` on the job so the dispatch API call is authorized (the `permissions:` block otherwise sets it to `none`).

0.28.0 assets are being backfilled by manually dispatching both pgwire workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)