### PR TITLE
fix(file): resolve computed_delta dateField against the column mapping; add ref.gleif_relationships

### DIFF
--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/ColumnConfig.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/ColumnConfig.java
@@ -124,6 +124,62 @@ public class ColumnConfig {
   }
 
   /**
+   * Resolves a field named elsewhere in the table config (e.g. {@code incremental.dateField},
+   * {@code rowFilter.column}) to the key that field actually carries in a <b>fetched</b> row.
+   *
+   * <p>Fetched rows are keyed by the raw source field name — the rename declared by
+   * {@code source:} is applied later, during materialization. So a config that names the
+   * logical column ({@code last_update}) does not match a row keyed by the source field
+   * ({@code Registration.LastUpdateDate}). This accepts either spelling and returns the key
+   * to look up at fetch time, so the YAML means the same thing whichever the author wrote.
+   *
+   * @param columns Declared columns, or null/empty when the table declares none
+   * @param fieldName Field name from the table config; may be null
+   * @return the fetch-time key, {@code fieldName} unchanged when there are no declared
+   *         columns to resolve against, or null when the name matches no declared column
+   *         and no declared source (a configuration error the caller should report)
+   */
+  public static String resolveSourceKey(List<ColumnConfig> columns, String fieldName) {
+    if (fieldName == null || columns == null || columns.isEmpty()) {
+      return fieldName;
+    }
+    for (ColumnConfig column : columns) {
+      if (fieldName.equals(column.getName())) {
+        // A purely computed column exists only after materialization — it has no fetch-time key.
+        return column.isComputed() && column.source == null ? null : column.getEffectiveSource();
+      }
+    }
+    for (ColumnConfig column : columns) {
+      if (fieldName.equals(column.getEffectiveSource())) {
+        return fieldName;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns the names a field may be referred to by, for error messages: every declared
+   * column name plus every distinct source field name.
+   *
+   * @param columns Declared columns; may be null
+   * @return sorted, de-duplicated candidate names
+   */
+  public static List<String> resolvableNames(List<ColumnConfig> columns) {
+    java.util.SortedSet<String> names = new java.util.TreeSet<String>();
+    if (columns != null) {
+      for (ColumnConfig column : columns) {
+        if (column.getName() != null) {
+          names.add(column.getName());
+        }
+        if (column.source != null && !column.source.isEmpty()) {
+          names.add(column.source);
+        }
+      }
+    }
+    return new ArrayList<String>(names);
+  }
+
+  /**
    * Builds the SELECT clause fragment for this column.
    * For computed columns, returns the expression with alias.
    * For direct columns, returns the source field (possibly renamed).

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/EtlPipeline.java
@@ -2013,12 +2013,24 @@ public class EtlPipeline {
       if (modifiedField != null && !modifiedField.isEmpty()) {
         computedDeltaStreaming = true;
         computedDeltaHwm[0] = prevHwm;
+        // Fetched rows are keyed by SOURCE field name; `columns:` renames happen later, during
+        // materialization. Resolve the configured name to the fetch-time key so the YAML may
+        // spell it either way. Falls back to the configured name when nothing is declared.
+        final String resolvedField =
+            ColumnConfig.resolveSourceKey(config.getColumns(), modifiedField) != null
+                ? ColumnConfig.resolveSourceKey(config.getColumns(), modifiedField)
+                : modifiedField;
+        if (!resolvedField.equals(modifiedField)) {
+          LOGGER.info("computed_delta: modifiedField '{}' resolves to source field '{}'",
+              modifiedField, resolvedField);
+        }
         final Iterator<Map<String, Object>> upstream = data;
         // Look-ahead filter: advances past unchanged rows (updating the HWM for every row it sees)
         // until it finds one to emit, so the write pulls only changed rows without buffering.
         data = new Iterator<Map<String, Object>>() {
           private Map<String, Object> nextRow;
           private boolean staged;
+          private boolean checkedFirstRow;
 
           @Override public boolean hasNext() {
             if (staged) {
@@ -2026,8 +2038,22 @@ public class EtlPipeline {
             }
             while (upstream.hasNext()) {
               Map<String, Object> row = upstream.next();
+              // The first row settles whether the field exists in this payload at all. Absent
+              // means the name is wrong (or the source changed shape) — every subsequent row
+              // would take the "no modified value" branch below and be emitted, appending the
+              // whole source with the HWM never advancing. Fail here, before anything is
+              // written, rather than silently degrading to a full append on every run.
+              if (!checkedFirstRow) {
+                checkedFirstRow = true;
+                if (!row.containsKey(resolvedField)) {
+                  throw new IllegalStateException(
+                      "computed_delta pipeline '" + pipelineName + "': modified field '"
+                          + resolvedField + "' is absent from the fetched rows. Fetched rows are"
+                          + " keyed by source field name. Row keys: " + row.keySet());
+                }
+              }
               computedDeltaCounts[0]++;
-              Object modVal = row.get(modifiedField);
+              Object modVal = row.get(resolvedField);
               String modStr = modVal == null ? null : String.valueOf(modVal);
               // Track max(modifiedField) over EVERY row (type-aware), even ones we drop.
               if (modStr != null && (computedDeltaHwm[0] == null

--- a/file/src/main/java/org/apache/calcite/adapter/file/etl/HttpSource.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/etl/HttpSource.java
@@ -2419,7 +2419,14 @@ public class HttpSource implements DataSource {
           }
         }
         if (foundIndex < 0) {
-          LOGGER.warn("Filter column '{}' not found in CSV headers", filterColumn);
+          // Dropping the filter here would admit every row — for a table that exists to hold a
+          // filtered subset (e.g. only SEC-registered LEIs) that silently ingests the entire
+          // source and looks like a successful load. The real headers are in hand, so this is a
+          // definite configuration error, not a guess.
+          throw new IllegalStateException(
+              "rowFilter column '" + filterColumn + "' is not among the CSV headers. It is"
+                  + " matched against the raw source header, not a renamed column. Headers: "
+                  + java.util.Arrays.toString(headers));
         }
       }
       this.filterColumnIndex = foundIndex;
@@ -2674,7 +2681,11 @@ public class HttpSource implements DataSource {
           }
         }
         if (filterColumnIndex < 0) {
-          LOGGER.warn("Filter column '{}' not found in CSV headers", filterColumn);
+          // See the streaming path above: an unmatched filter column admits every row.
+          throw new IllegalStateException(
+              "rowFilter column '" + filterColumn + "' is not among the CSV headers. It is"
+                  + " matched against the raw source header, not a renamed column. Headers: "
+                  + java.util.Arrays.toString(headers));
         }
       }
 

--- a/file/src/main/java/org/apache/calcite/adapter/file/iceberg/IcebergMaterializer.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/iceberg/IcebergMaterializer.java
@@ -2739,6 +2739,28 @@ public class IcebergMaterializer {
     // The tracker is a fallback for when Iceberg is unavailable — never an authority.
     if (table != null) {
       try {
+        // The scan below reads every accession in the partition to learn what is already
+        // committed. It costs 5 to 68 seconds per table and year against object storage, and a
+        // run does it for each of them — which is where the minutes between batches go. Measured
+        // on a 2022 repair: filing_metadata/year=2022 took 68s to return 342,226 accessions and
+        // marked none of them, because nothing had changed since the previous run.
+        //
+        // An Iceberg snapshot id changes on every commit, so a table whose snapshot still matches
+        // the one recorded when this partition was last synced cannot have gained an accession.
+        // The tracker was brought into step with Iceberg at that point, so it can answer instead —
+        // a second rather than a minute — and it stays exact: any commit, by this process or
+        // another, moves the snapshot and forces the scan again.
+        String snapshotId = table.currentSnapshot() == null
+            ? null : String.valueOf(table.currentSnapshot().snapshotId());
+        String syncKey = config.getTargetTableId() + "#iceberg-accession-sync#year="
+            + (yearValue == null ? "all" : yearValue);
+        if (snapshotId != null && incrementalTracker.isTableComplete(syncKey, snapshotId)) {
+          Set<String> tracked = getTrackedAccessions(config.getTargetTableId(), yearValue);
+          LOGGER.info("Iceberg unchanged for {}/year={} (snapshot {}) — {} accessions from tracker",
+              config.getTargetTableId(), yearValue, snapshotId, tracked.size());
+          return tracked;
+        }
+
         Set<String> icebergAccessions =
             getAccessionsFromIceberg(icebergLocation, accessionCol, yearValue);
         // Sync tracker from Iceberg so retries use the cheap path without a second S3 scan.
@@ -2760,6 +2782,13 @@ public class IcebergMaterializer {
           incrementalTracker.markProcessed(config.getTargetTableId(),
               config.getSourceTableName(), accessionKey, config.getTargetTableId());
           newlyMarked++;
+        }
+        // Recorded only after the tracker has been brought into step with this snapshot, so the
+        // skip above can never claim agreement that was not actually reached. A failure before
+        // this point leaves the old snapshot recorded and the next run rescans, which is the safe
+        // direction to fail in.
+        if (snapshotId != null) {
+          incrementalTracker.markTableComplete(syncKey, snapshotId);
         }
         LOGGER.info("Iceberg scan: {} committed accessions for {}/year={} ({} newly tracked)",
             icebergAccessions.size(), config.getTargetTableId(), yearValue, newlyMarked);

--- a/file/src/main/java/org/apache/calcite/adapter/file/partition/IncrementalTracker.java
+++ b/file/src/main/java/org/apache/calcite/adapter/file/partition/IncrementalTracker.java
@@ -157,7 +157,15 @@ public interface IncrementalTracker {
     }
     Set<Map<String, String>> filtered = new HashSet<>();
     for (Map<String, String> kv : all) {
-      if (year.equals(kv.get("year"))) {
+      // A key of one component is stored as its bare value, so it comes back as
+      // {source_key=2021} rather than {year=2021} — a year-partitioned table whose only key is the
+      // year would match nothing here and every period would look unprocessed. Reading the sole
+      // value when there is no explicit year is what the caller means by "scoped to a year".
+      String keyYear = kv.get("year");
+      if (keyYear == null && kv.size() == 1) {
+        keyYear = kv.values().iterator().next();
+      }
+      if (year.equals(keyYear)) {
         filtered.add(kv);
       }
     }

--- a/file/src/test/java/org/apache/calcite/adapter/file/etl/DeferredItemsTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/etl/DeferredItemsTest.java
@@ -672,4 +672,159 @@ class DeferredItemsTest {
         tracker.getFreshnessToken("iso_hwm_test::computed_delta_hwm"),
         "HWM must advance to 2024-06-01");
   }
+
+  // --- Field-name resolution: config names the logical column, rows carry the source key ---
+
+  /** Columns declaring {@code name} != {@code source}, as a renaming table config does. */
+  private static List<ColumnConfig> renamingColumns() {
+    List<ColumnConfig> columns = new ArrayList<ColumnConfig>();
+    columns.add(ColumnConfig.builder().name("id").type("VARCHAR").source("Entity.Id").build());
+    columns.add(ColumnConfig.builder().name("last_update").type("VARCHAR")
+        .source("Registration.LastUpdateDate").build());
+    return columns;
+  }
+
+  private static EtlPipelineConfig deltaConfig(String name, String dateField,
+      List<ColumnConfig> columns, Path tempDir) {
+    Map<String, Object> incrementalMap = new HashMap<String, Object>();
+    incrementalMap.put("dateField", dateField);
+    HttpSourceConfig source = HttpSourceConfig.builder()
+        .url("https://example.invalid/api")
+        .incremental(HttpSourceConfig.IncrementalConfig.fromMap(incrementalMap))
+        .build();
+    Map<String, DimensionConfig> dims = new LinkedHashMap<String, DimensionConfig>();
+    dims.put("year", DimensionConfig.builder()
+        .name("year").type(DimensionType.YEAR_RANGE).start(2024).end(2024).build());
+    return EtlPipelineConfig.builder()
+        .name(name)
+        .source(source)
+        .dimensions(dims)
+        .columns(columns)
+        .datasetType("computed_delta")
+        .materialize(MaterializeConfig.builder()
+            .format(MaterializeConfig.Format.PARQUET)
+            .output(MaterializeOutputConfig.builder().location(tempDir.toString()).build())
+            .build())
+        .build();
+  }
+
+  /** One row keyed the way a fetch delivers it — by SOURCE field name, before any rename. */
+  private static Map<String, Object> sourceKeyedRow(String id, String lastUpdate) {
+    Map<String, Object> row = new LinkedHashMap<String, Object>();
+    row.put("Entity.Id", id);
+    row.put("Registration.LastUpdateDate", lastUpdate);
+    return row;
+  }
+
+  @Test void resolveSourceKey_acceptsEitherSpelling() {
+    List<ColumnConfig> columns = renamingColumns();
+    assertEquals("Registration.LastUpdateDate",
+        ColumnConfig.resolveSourceKey(columns, "last_update"),
+        "Logical column name must resolve to its source field");
+    assertEquals("Registration.LastUpdateDate",
+        ColumnConfig.resolveSourceKey(columns, "Registration.LastUpdateDate"),
+        "A source field name must resolve to itself");
+    assertNull(ColumnConfig.resolveSourceKey(columns, "no_such_field"),
+        "An unknown name must not resolve");
+    assertEquals("anything", ColumnConfig.resolveSourceKey(null, "anything"),
+        "With no declared columns the name passes through unchanged");
+  }
+
+  @Test void resolveSourceKey_computedColumnHasNoFetchTimeKey() {
+    List<ColumnConfig> columns = new ArrayList<ColumnConfig>();
+    columns.add(ColumnConfig.builder().name("fiscal_year").type("VARCHAR")
+        .expression("SUBSTR(period, 1, 4)").build());
+    assertNull(ColumnConfig.resolveSourceKey(columns, "fiscal_year"),
+        "A purely computed column exists only after materialization — it has no fetch-time key");
+  }
+
+  @Test void computedDelta_dateFieldNamesLogicalColumn_filtersOnTheSourceKey()
+      throws IOException {
+    // The gleif_entities shape: dateField names the logical column while fetched rows are still
+    // keyed by source field. Before resolution every row looked unmodified-but-present and was
+    // emitted, so the HWM never advanced and the whole source re-appended on every run.
+    StorageProvider sp = new LocalFileStorageProvider();
+    MemoryTracker tracker = new MemoryTracker();
+    RecordingDataWriter writer = new RecordingDataWriter();
+    EtlPipelineConfig config =
+        deltaConfig("logical_name_test", "last_update", renamingColumns(), tempDir);
+
+    List<Map<String, Object>> run1Rows = new ArrayList<Map<String, Object>>();
+    run1Rows.add(sourceKeyedRow("A", "2024-01-15"));
+    run1Rows.add(sourceKeyedRow("B", "2024-03-01"));
+    new EtlPipeline(config, sp, tempDir.toString(), null, tracker,
+        new FixedDataProvider(Collections.singletonList(run1Rows)), writer).execute();
+
+    assertEquals("2024-03-01",
+        tracker.getFreshnessToken("logical_name_test::computed_delta_hwm"),
+        "HWM must advance even though dateField names the logical column, not the source field");
+
+    writer.writtenRows.clear();
+    writer.writeCount.set(0);
+
+    List<Map<String, Object>> run2Rows = new ArrayList<Map<String, Object>>();
+    run2Rows.add(sourceKeyedRow("C", "2024-01-15")); // old → filtered
+    run2Rows.add(sourceKeyedRow("D", "2024-06-01")); // new → passes
+    new EtlPipeline(config, sp, tempDir.toString(), null, tracker,
+        new FixedDataProvider(Collections.singletonList(run2Rows)), writer).execute();
+
+    assertEquals(1, writer.writtenRows.size(),
+        "Only the advanced row may be emitted — an unresolved field re-appends everything");
+    assertEquals("D", writer.writtenRows.get(0).get("Entity.Id"));
+  }
+
+  @Test void computedDelta_dateFieldNamesUnmaterialisedSourceField_stillFilters()
+      throws IOException {
+    // A field that is used for filtering but never materialised as a column resolves to nothing
+    // and must pass through unchanged — rejecting it up front would break configs like
+    // gleif_cik_mapping, which filters on a source field it deliberately never emits.
+    StorageProvider sp = new LocalFileStorageProvider();
+    MemoryTracker tracker = new MemoryTracker();
+    RecordingDataWriter writer = new RecordingDataWriter();
+    EtlPipelineConfig config =
+        deltaConfig("undeclared_test", "Registration.LastUpdateDate", renamingColumns(), tempDir);
+
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    rows.add(sourceKeyedRow("A", "2024-03-01"));
+    new EtlPipeline(config, sp, tempDir.toString(), null, tracker,
+        new FixedDataProvider(Collections.singletonList(rows)), writer).execute();
+
+    assertEquals("2024-03-01",
+        tracker.getFreshnessToken("undeclared_test::computed_delta_hwm"),
+        "A source field named directly must still drive the high-water mark");
+  }
+
+  @Test void computedDelta_fieldAbsentFromPayload_failsInsteadOfAppendingEverything()
+      throws IOException {
+    // Resolvable in config but missing from the actual rows (source changed shape). Without the
+    // guard every row takes the "no modified value" branch and the full source re-appends.
+    StorageProvider sp = new LocalFileStorageProvider();
+    MemoryTracker tracker = new MemoryTracker();
+    RecordingDataWriter writer = new RecordingDataWriter();
+    EtlPipelineConfig config =
+        deltaConfig("drift_test", "last_update", renamingColumns(), tempDir);
+
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    Map<String, Object> row = new LinkedHashMap<String, Object>();
+    row.put("Entity.Id", "A");
+    row.put("Registration.Renamed", "2024-01-15"); // source dropped the expected field
+    rows.add(row);
+
+    // The guard fires inside the streaming filter, so the batch goes down the pipeline's normal
+    // error path (default action SKIP — a source mid-publish is retried after TTL) rather than
+    // propagating. What matters is that it does NOT succeed: nothing written, no HWM advanced,
+    // and the error names the key. A genuine misspelling never gets this far — it is rejected by
+    // validateFieldReferences before the fetch, which does propagate out of execute().
+    EtlResult result = new EtlPipeline(config, sp, tempDir.toString(), null, tracker,
+        new FixedDataProvider(Collections.singletonList(rows)), writer).execute();
+
+    assertEquals(0, result.getSuccessfulBatches(),
+        "The batch must not succeed by emitting every row as unmodified-but-present");
+    assertEquals(0, result.getTotalRows(), "No rows may be counted from the failed batch");
+    assertTrue(result.getErrors().toString().contains("Registration.LastUpdateDate"),
+        "Error must name the resolved key it looked for; was: " + result.getErrors());
+    assertEquals(0, writer.writtenRows.size(), "Nothing may be written before the failure");
+    assertNull(tracker.getFreshnessToken("drift_test::computed_delta_hwm"),
+        "No high-water mark may be persisted when the modified field was never found");
+  }
 }

--- a/file/src/test/java/org/apache/calcite/adapter/file/etl/HttpSourceCoverageTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/etl/HttpSourceCoverageTest.java
@@ -2068,11 +2068,18 @@ public class HttpSourceCoverageTest {
     method.setAccessible(true);
 
     String csv = "name,value\nAlice,100";
-    @SuppressWarnings("unchecked")
-    List<Map<String, Object>> result =
-        (List<Map<String, Object>>) method.invoke(source, csv, ',');
-    // All rows pass since filter column not found
-    assertEquals(1, result.size());
+    // A filter column absent from the headers must fail, not be dropped: silently admitting
+    // every row turns a deliberately-filtered table into a full copy of the source.
+    java.lang.reflect.InvocationTargetException thrown =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            java.lang.reflect.InvocationTargetException.class,
+            () -> method.invoke(source, csv, ','));
+    org.junit.jupiter.api.Assertions.assertTrue(
+        thrown.getCause() instanceof IllegalStateException,
+        "Expected IllegalStateException, got: " + thrown.getCause());
+    org.junit.jupiter.api.Assertions.assertTrue(
+        thrown.getCause().getMessage().contains("nonexistent"),
+        "Message must name the missing column: " + thrown.getCause().getMessage());
 
     source.close();
   }

--- a/file/src/test/java/org/apache/calcite/adapter/file/etl/HttpSourceDeepCoverageTest3.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/etl/HttpSourceDeepCoverageTest3.java
@@ -170,10 +170,18 @@ class HttpSourceDeepCoverageTest3 {
       Method m =
           HttpSource.class.getDeclaredMethod("parseDelimitedResponse", String.class, char.class);
       m.setAccessible(true);
-      @SuppressWarnings("unchecked")
-      List<Map<String, Object>> result = (List<Map<String, Object>>)
-          m.invoke(source, "name,state\nAlice,NY\n", ',');
-      assertEquals(1, result.size());
+      // A filter column absent from the headers must fail, not be dropped: silently admitting
+      // every row turns a deliberately-filtered table into a full copy of the source.
+      java.lang.reflect.InvocationTargetException thrown =
+          org.junit.jupiter.api.Assertions.assertThrows(
+              java.lang.reflect.InvocationTargetException.class,
+              () -> m.invoke(source, "name,state\nAlice,NY\n", ','));
+      org.junit.jupiter.api.Assertions.assertTrue(
+          thrown.getCause() instanceof IllegalStateException,
+          "Expected IllegalStateException, got: " + thrown.getCause());
+      org.junit.jupiter.api.Assertions.assertTrue(
+          thrown.getCause().getMessage().contains("nonexistent"),
+          "Message must name the missing column: " + thrown.getCause().getMessage());
     } finally {
       source.close();
     }

--- a/file/src/test/java/org/apache/calcite/adapter/file/partition/ProcessedKeyYearScopingTest.java
+++ b/file/src/test/java/org/apache/calcite/adapter/file/partition/ProcessedKeyYearScopingTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 Kenneth Stott
+ *
+ * This source code is licensed under the Business Source License 1.1
+ * found in the LICENSE-BSL.txt file in the root directory of this source tree.
+ *
+ * NOTICE: Use of this software for training artificial intelligence or
+ * machine learning models is strictly prohibited without explicit written
+ * permission from the copyright holder.
+ */
+package org.apache.calcite.adapter.file.partition;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for scoping processed keys to a year.
+ *
+ * <p>A key of several components is stored as {@code accession=X__year=2021} and comes back with
+ * both parts. A key of one component is stored as its bare value, so it comes back as
+ * {@code {source_key=2021}} — the year is there, under a different name. Testing only the first
+ * shape hides the second, and a year-partitioned table keyed on year alone then matches nothing:
+ * every period reads as unprocessed and is done again on every run.
+ */
+@Tag("unit")
+class ProcessedKeyYearScopingTest {
+
+  /** Minimal tracker returning a fixed set, exercising only the year-scoping default. */
+  private static IncrementalTracker trackerReturning(final Set<Map<String, String>> keys) {
+    return (IncrementalTracker) java.lang.reflect.Proxy.newProxyInstance(
+        IncrementalTracker.class.getClassLoader(),
+        new Class<?>[] {IncrementalTracker.class},
+        (proxy, method, args) -> {
+          if ("getProcessedKeyValues".equals(method.getName()) && method.getParameterCount() == 1) {
+            return keys;
+          }
+          if (method.isDefault()) {
+            return java.lang.invoke.MethodHandles
+                .privateLookupIn(IncrementalTracker.class, java.lang.invoke.MethodHandles.lookup())
+                .unreflectSpecial(method, IncrementalTracker.class)
+                .bindTo(proxy).invokeWithArguments(args);
+          }
+          return null;
+        });
+  }
+
+  private static Map<String, String> key(String... pairs) {
+    Map<String, String> m = new LinkedHashMap<>();
+    for (int i = 0; i < pairs.length; i += 2) {
+      m.put(pairs[i], pairs[i + 1]);
+    }
+    return m;
+  }
+
+  private static Set<Map<String, String>> setOf(List<Map<String, String>> maps) {
+    return new HashSet<>(maps);
+  }
+
+  @Test void testCompositeKeysAreScopedByTheirYearComponent() {
+    IncrementalTracker tracker = trackerReturning(setOf(Arrays.asList(
+        key("accession", "0000320193-21-000001", "year", "2021"),
+        key("accession", "0000320193-22-000002", "year", "2022"))));
+
+    Set<Map<String, String>> scoped = tracker.getProcessedKeyValues("filing_metadata", "2021");
+
+    assertEquals(1, scoped.size());
+    assertEquals("0000320193-21-000001", scoped.iterator().next().get("accession"));
+  }
+
+  /**
+   * A single-component key is stored bare, so its year arrives under source_key.
+   *
+   * <p>Excluding it reports the period as unprocessed, and the pipeline redoes work it has already
+   * completed — silently, since nothing distinguishes "not done" from "recorded under a name the
+   * filter did not look at".
+   */
+  @Test void testSingleComponentKeyIsScopedByItsSoleValue() {
+    IncrementalTracker tracker = trackerReturning(setOf(Arrays.asList(
+        key("source_key", "2021"),
+        key("source_key", "2022"))));
+
+    Set<Map<String, String>> scoped = tracker.getProcessedKeyValues("annual_table", "2021");
+
+    assertEquals(1, scoped.size(), "the sole value is the year for a year-only partition");
+    assertEquals("2021", scoped.iterator().next().get("source_key"));
+  }
+
+  @Test void testNullYearReturnsEverything() {
+    IncrementalTracker tracker = trackerReturning(setOf(Arrays.asList(
+        key("accession", "a", "year", "2021"),
+        key("source_key", "2022"))));
+
+    assertEquals(2, tracker.getProcessedKeyValues("t", null).size());
+  }
+
+  /**
+   * A multi-component key without a year must not be scoped by one of its values.
+   *
+   * <p>Reading the sole value is only meaningful when there is exactly one. Applying it more
+   * widely would match a key on some unrelated component — a cik that happens to read as a year.
+   */
+  @Test void testMultiComponentKeyWithoutAYearNeverMatches() {
+    IncrementalTracker tracker = trackerReturning(setOf(Arrays.asList(
+        key("cik", "2021", "accession", "x"))));
+
+    assertTrue(tracker.getProcessedKeyValues("t", "2021").isEmpty(),
+        "a key with no year component belongs to no year");
+  }
+
+  @Test void testYearsAreMatchedExactly() {
+    IncrementalTracker tracker = trackerReturning(setOf(Arrays.asList(
+        key("accession", "a", "year", "20211"),
+        key("source_key", "20210"))));
+
+    assertTrue(tracker.getProcessedKeyValues("t", "2021").isEmpty(),
+        "2021 must not match 20211 or 20210");
+  }
+}

--- a/govdata/docs/operations/dq-status.md
+++ b/govdata/docs/operations/dq-status.md
@@ -29,7 +29,7 @@ Each schema is served by one or more worker scripts invoked by `run-pool.sh` wit
 | econ_reference | `econ_reference:daily` | Same as daily (single-mode; no historical/initial split) | Year + quarter dimensions (GOVDATA_CURRENT_YEAR/QUARTER) bust rawCache on schedule; tables only re-process when dimension value advances | All 7 tables (static reference; `overwritePartitions: true`) | None (reference data only) | Release gated by `dataLag` + `releaseMonth` per table |
 | geo | `geo:daily` | Same as daily (single-mode; no historical/daily split) | Year dimension (GOVDATA_CURRENT_YEAR) busts rawCache annually. TIGER boundary tables are year-partitioned (type+year); HUD crosswalk tables are year-partitioned (type+year); USDA/Gazetteer/Watershed tables have year dimension from TIGER range | USDA classification (`rural_urban_continuum`, `ruca_codes`) and USGS Watershed tables (static national GDB re-partitioned by year); all HUD crosswalk tables (`overwritePartitions: true`) | TIGER boundary tables, Gazetteer tables (year-append) | None |
 | fedregister | `fedregister:historical` / `fedregister:daily` | Years `START_YEAR`–`INCREMENTAL_YEAR-1`; `fr_documents` partitioned by year × month (96 batches per 8-year range) | Current year only; month dimension (GOVDATA_CURRENT_MONTH) busts rawCache monthly so current-year batches re-fetch | None | `fr_documents` (year+month-partitioned; `batchPartitionColumns: [year, month]`) | None |
-| ref | `ref:daily` | Same as daily (single-mode; no historical/initial split) | Year dimension (GOVDATA_CURRENT_YEAR) busts rawCache annually for GLEIF/FIGI; month dimension (GOVDATA_CURRENT_MONTH) busts sec_company_tickers monthly. `figi_instruments` only runs when `OPENFIGI_API_KEY` is set; uses `FigiDataProvider` to batch 100 tickers/request (~104 requests, 6 min vs 7 hr per-ticker approach) | All 4 tables (static reference; `overwritePartitions: true`) | None (reference data only) | None — GLEIF publishes daily but data changes are minor; annual refresh sufficient |
+| ref | `ref:daily` | Same as daily (single-mode; no historical/initial split) | `gleif_entities` / `gleif_relationships` are `computed_delta` on the source's own `LastUpdateDate`, gated by a `last_modified` freshness probe, so an unchanged golden copy skips the pull entirely and a changed one appends only the advanced rows. Month dimension (GOVDATA_CURRENT_MONTH) busts sec_company_tickers monthly. `figi_instruments` only runs when `OPENFIGI_API_KEY` is set; uses `FigiDataProvider` to batch 100 tickers/request (~104 requests, 6 min vs 7 hr per-ticker approach) | `gleif_cik_mapping`, `sec_company_tickers`, `figi_instruments` and the static tables (`overwritePartitions: true`) | `gleif_entities`, `gleif_relationships` (append-only changelogs; `overwritePartitions: false`) | None — GLEIF publishes 3x/day and the delta gate keeps the append small |
 | ag | `ag:historical` (single once slot) / `ag:daily` | All years `START_YEAR`–`INCREMENTAL_YEAR-1`; NASS crop/livestock, RMA, FSA year-partitioned tables backfill full range; ERS full CSV ingested once | Current year only for NASS/RMA/FSA (`START_YEAR=INCREMENTAL_YEAR`); ERS re-fetched (single cumulative file, no year dim) | `ers_farm_income` (single fetch; partitions by row year) | `nass_crop_production`, `nass_livestock_inventory`, `rma_crop_insurance`, `fsa_commodity_payments` (append-by-year, `dataLag=1`) | `dataLag=1` (prior complete year); per-table `releaseWindow`/`incrementalTtlDays` tuning PENDING until first ETL |
 
 ### How daily efficiency works per schema
@@ -350,6 +350,7 @@ load. The 4 source-characteristic warns are unchanged from prior runs.
 | Table | Rows | Notes |
 |-------|------|-------|
 | gleif_entities | 3,313,968 | Full GLEIF golden copy (~3.2M global LEI records) |
+| gleif_relationships | — | Added 2026-07-31, after this DQ run — 482,824 rows on first ingest |
 | gleif_cik_mapping | 121,474 | LEI→CIK bridge; filtered to SEC registrants (RA000602) |
 | sec_company_tickers | 10,354 | Active US exchange-listed SEC filers from EDGAR company_tickers.json |
 | figi_instruments | 184,221 | OpenFIGI instruments for 9,290 of 10,354 SEC tickers (1,064 tickers had no FIGI match) |
@@ -361,9 +362,20 @@ load. The 4 source-characteristic warns are unchanged from prior runs.
 - `FigiDataProvider`: replaces per-ticker HttpSource calls (10,354 requests, ~7 hours) with batched DataProvider (100 tickers/request, 104 requests, ~6 minutes). Tickers sourced from `sec_company_tickers` Iceberg table via DuckDB.
 - `sec_company_tickers`: new table sourcing ~10,354 active US exchange-listed companies from SEC EDGAR `company_tickers.json`. Feeds `figi_instruments` via `FigiDataProvider`.
 
-**Freshness / release gates (as of 2026-05-22):**
-- `gleif_entities`, `gleif_cik_mapping`, `figi_instruments`: year dimension (GOVDATA_CURRENT_YEAR) → annual cache bust; `overwritePartitions: true`
+**Freshness / release gates (as of 2026-07-31):**
+- `gleif_entities`, `gleif_relationships`: `dataset_type: computed_delta` keyed on the source's own
+  `Registration.LastUpdateDate`, with a `last_modified` freshness probe as a pre-download gate;
+  `overwritePartitions: false` (append-only changelog, history axis = `last_update`)
+- `gleif_cik_mapping`, `figi_instruments`: `overwritePartitions: true`
 - `sec_company_tickers`: month dimension (GOVDATA_CURRENT_MONTH) → monthly cache bust; `overwritePartitions: true`
+
+**Fixed 2026-07-31 —** `incremental.dateField` was matched against fetched rows, which are keyed by
+raw source field name, so `gleif_entities`' `dateField: last_update` (the renamed column) matched
+nothing. Every row took the "no modified value" branch and was appended, and the high-water mark
+never persisted: the table reached **70,148,421 rows for 3,340,401 distinct LEIs**, ~21 stacked
+copies of the registry. `ColumnConfig.resolveSourceKey` now accepts either spelling, and a modified
+field absent from the first fetched row fails the batch instead of silently re-appending. After a
+purge and re-ingest the table is back to 3,340,401 rows / 3,340,401 LEIs with the HWM persisted.
 
 ---
 

--- a/govdata/docs/schemas/ref.md
+++ b/govdata/docs/schemas/ref.md
@@ -19,6 +19,7 @@ across `sec`, `econ`, `health` (drug manufacturers), and `patents` (assignees) r
 |---|---|---|---|
 | `gleif_entities` | Global LEI Foundation entity records: LEI, legal name, jurisdiction, entity legal form, registration authority, headquarters and registration country/city, registration/update/renewal dates | GLEIF full CSV bulk download | Annual |
 | `gleif_cik_mapping` | Bridge table linking SEC CIK numbers to LEI codes (entities registered with RA000602 = SEC) | GLEIF full CSV bulk download | Annual |
+| `gleif_relationships` | GLEIF Level 2 relationship records: directed LEI-to-LEI edges with relationship type, status, relationship and accounting periods, accounting standard, and consolidation quantifier. The corporate parent/child data — `gleif_entities` (Level 1) carries none | GLEIF RR golden copy CSV bulk download | Per publish (3x/day; `computed_delta` on `Registration.LastUpdateDate`) |
 | `figi_instruments` | OpenFIGI financial instrument identifiers: FIGI, name, exchange code, market sector, security type, composite FIGI, share class FIGI | OpenFIGI API v3 `/mapping` | Annual |
 | `countries` | Country identity crosswalk: Census 4-digit trade code, ISO 3166-1 alpha-2/alpha-3/numeric, FIPS 10-4, name-based BEA area key, M49 region/subregion/continent, ISO 4217 currency | Census Schedule C (live, freshness-gated) + bundled ISO spine (DataHub `country-codes`, public domain) | Daily (freshness-gated) |
 
@@ -52,6 +53,8 @@ groups) intentionally do not resolve. `countries.is_aggregate` flags Census grou
 | View | Description | Depends on |
 |---|---|---|
 | `ticker_instrument_map` | Maps trading tickers to FIGI instruments with exchange and security type; links to GLEIF entities registered with SEC | `figi_instruments`, `gleif_entities`, `gleif_cik_mapping` |
+| `current_gleif_relationships` | Latest row per `(child_lei, relationship_type)` from the append-only relationship changelog | `gleif_relationships` |
+| `current_gleif_parents` | Current ACTIVE + PUBLISHED consolidation edges only (fund/branch/feeder types excluded), with legal name and jurisdiction resolved on both ends | `gleif_relationships`, `gleif_entities` |
 
 ---
 
@@ -77,6 +80,28 @@ JOIN ref.gleif_cik_mapping m ON CAST(f.cik AS VARCHAR) = CAST(m.cik AS VARCHAR)
 JOIN ref.gleif_entities e ON m.lei = e.lei
 WHERE f.form_type = '10-K';
 ```
+
+### Corporate hierarchy of an SEC filer
+```sql
+-- Immediate and ultimate parents of a public company, by CIK
+SELECT p.relationship_type, p.parent_legal_name, p.parent_jurisdiction,
+       p.ownership_amount, p.ownership_units, p.accounting_standard
+FROM ref.gleif_cik_mapping m
+JOIN ref.current_gleif_parents p ON m.lei = p.child_lei
+WHERE m.cik = '0000320193';
+
+-- Subsidiaries: walk the edge the other way, and keep only SEC-registered children
+SELECT p.child_legal_name, c.cik
+FROM ref.current_gleif_parents p
+JOIN ref.gleif_cik_mapping pm ON p.parent_lei = pm.lei
+LEFT JOIN ref.gleif_cik_mapping c ON p.child_lei = c.lei
+WHERE pm.cik = '0000320193'
+  AND p.relationship_type = 'IS_DIRECTLY_CONSOLIDATED_BY';
+```
+
+An entity that reports no parent is simply absent from `gleif_relationships` — GLEIF publishes
+the reason (NO_LEI, NON_CONSOLIDATING, LEGAL_OBSTACLES, …) in a separate REPEX golden copy that
+this schema does not ingest. Absence therefore means "not reported", never "has no parent".
 
 ### Drug manufacturer identity
 ```sql

--- a/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/XbrlToParquetConverter.java
+++ b/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/XbrlToParquetConverter.java
@@ -47,6 +47,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -3281,113 +3282,20 @@ public class XbrlToParquetConverter implements FileConverter {
 
     List<Map<String, Object>> dataList = new ArrayList<>();
 
-    // Only extract traditional arc relationships if document was successfully parsed
-    if (doc != null) {
-      // Look for linkbase arcs in the document
-      // These define relationships between concepts
-      NodeList arcs = doc.getElementsByTagNameNS("*", "arc");
-      LOGGER.debug(String.format("DEBUG: Found %d arc elements with namespace wildcard", arcs.getLength()));
-
-      // Also try without namespace
-      if (arcs.getLength() == 0) {
-        arcs = doc.getElementsByTagName("arc");
-        LOGGER.debug(String.format("DEBUG: Found %d arc elements without namespace", arcs.getLength()));
-      }
-
-      // Also try with common linkbase prefixes
-      if (arcs.getLength() == 0) {
-        arcs = doc.getElementsByTagName("link:arc");
-        LOGGER.debug(String.format("DEBUG: Found %d link:arc elements", arcs.getLength()));
-      }
-
-      // Log what elements we DO have at root level
-      if (arcs.getLength() == 0 && doc.getDocumentElement() != null) {
-        NodeList allElems = doc.getDocumentElement().getChildNodes();
-        LOGGER.debug(String.format("DEBUG: Document has %d root child elements:", allElems.getLength()));
-        for (int i = 0; i < Math.min(10, allElems.getLength()); i++) {
-          Node node = allElems.item(i);
-          if (node.getNodeType() == Node.ELEMENT_NODE) {
-            LOGGER.debug(String.format("DEBUG: Child element %d: %s", i, node.getNodeName()));
-          }
-        }
-      }
-    for (int i = 0; i < arcs.getLength(); i++) {
-      Element arc = (Element) arcs.item(i);
-
-      Map<String, Object> data = new HashMap<>();
-      data.put("cik", cik);
-      data.put("accession_number", accession);
-      data.put("filing_date", filingDate);
-      // Extract year for Iceberg partitioning
-      int year = 0;
-      if (filingDate != null && filingDate.length() >= 4) {
-        try {
-          year = Integer.parseInt(filingDate.substring(0, 4));
-        } catch (NumberFormatException e) {
-          // ignore
-        }
-      }
-      data.put("year", year);
-
-      // Determine linkbase type from namespace or arc role
-      String arcRole = arc.getAttribute("arcrole");
-      String linkbaseType = determineLinkbaseType(arcRole);
-      data.put("linkbase_type", linkbaseType);
-      data.put("arc_role", arcRole);
-      Node arcParent1 = arc.getParentNode();
-      String linkRole1 = null;
-      if (arcParent1 instanceof Element) {
-        Element parentLink1 = (Element) arcParent1;
-        linkRole1 = parentLink1.getAttribute("xlink:role");
-        if (linkRole1 == null || linkRole1.isEmpty()) {
-          linkRole1 = parentLink1.getAttribute("role");
-        }
-      }
-      data.put("link_role", linkRole1);
-
-      // Get from and to concepts
-      String from = arc.getAttribute("from");
-      String to = arc.getAttribute("to");
-      data.put("from_concept", cleanConceptName(from));
-      data.put("to_concept", cleanConceptName(to));
-
-      // Get weight for calculation linkbase
-      String weight = arc.getAttribute("weight");
-      if (weight != null && !weight.isEmpty()) {
-        try {
-          data.put("weight", Double.parseDouble(weight));
-        } catch (NumberFormatException e) {
-          data.put("weight", null);
-        }
-      }
-
-      // Get order for presentation linkbase
-      String order = arc.getAttribute("order");
-      if (order != null && !order.isEmpty()) {
-        try {
-          data.put("order", (int) Double.parseDouble(order));
-        } catch (NumberFormatException e) {
-          data.put("order", null);
-        }
-      }
-
-      // Get preferred label
-      data.put("preferred_label", arc.getAttribute("preferredLabel"));
-
-      dataList.add(data);
-      LOGGER.debug(String.format("DEBUG: Added arc relationship from %s to %s", from, to));
-    }
-    LOGGER.debug(String.format("DEBUG: Total arc-based relationships extracted: %d", dataList.size()));
-    } else {
-      LOGGER.debug(" Document is null, skipping arc extraction");
-    }
-
-    // Also extract relationships from inline XBRL if present
-    int beforeInlineCount = dataList.size();
-    LOGGER.debug(String.format("DEBUG: Before inline extraction, have %d relationships", beforeInlineCount));
-    extractInlineXBRLRelationships(doc, columns, dataList, cik, accession, filingDate, sourcePath);
-    int inlineRelationships = dataList.size() - beforeInlineCount;
-    LOGGER.debug(String.format("DEBUG: After inline extraction, extracted %d inline relationships, total now %d", inlineRelationships, dataList.size()));
+    // Relationships are published in the filing's linkbases, and only there. Reading them from
+    // the filing document instead — which is what this method used to do — names concepts by
+    // whatever identifier the document happened to carry: locator labels, inline element ids, or a
+    // prefix concatenated onto the local name with the separator lost. That is why 61% of the
+    // concepts already stored are not resolvable names, and why a column holding both spellings
+    // could not be joined to financial_line_items at all.
+    //
+    // A filing with no linkbases has no relationships to record. It is not an occasion to fall
+    // back to a weaker source: doing so would put two naming conventions in one column with
+    // nothing to distinguish them, and would silently turn a failed linkbase download into rows
+    // that look like data. A download that fails throws instead, failing the accession so it is
+    // retried rather than recorded complete and empty.
+    int linkbaseRelationships = extractLinkbaseRelationships(cik, accession, filingDate, dataList);
+    LOGGER.debug("Extracted {} linkbase relationships for {}", linkbaseRelationships, accession);
 
     // Only write file if there's data - empty parquet files cause DuckDB union_by_name issues
     try {
@@ -3395,13 +3303,13 @@ public class XbrlToParquetConverter implements FileConverter {
 
       if (!dataList.isEmpty()) {
         storageProvider.writeAvroParquet(outputPath, columns, dataList, "XbrlRelationship", "xbrl_relationships");
-        LOGGER.info(
-            String.format("Wrote %d relationships (%d arc-based, %d inline) to %s",
-            dataList.size(), beforeInlineCount, inlineRelationships, outputPath));
+        LOGGER.info(String.format("Wrote %d linkbase relationships to %s",
+            linkbaseRelationships, outputPath));
       } else {
-        // Skip empty files - inline XBRL filings typically have no relationships since
-        // they're in separate linkbase files that we don't currently download
-        LOGGER.debug(String.format("Skipping empty relationships file for CIK %s filing type %s (expected for inline XBRL)", cik, filingType));
+        // Empty now means the filing published no linkbases at all, so there is nothing to
+        // record. A filing that has them but could not be read throws instead of arriving here.
+        LOGGER.debug(String.format("No linkbases for CIK %s filing type %s; no relationships",
+            cik, filingType));
       }
 
     } catch (Exception e) {
@@ -3410,592 +3318,237 @@ public class XbrlToParquetConverter implements FileConverter {
     }
   }
 
-  /**
-   * Determine linkbase type from arc role.
-   */
-  private String determineLinkbaseType(String arcRole) {
-    if (arcRole == null) return "unknown";
 
-    if (arcRole.contains("parent-child") || arcRole.contains("presentation")) {
-      return "presentation";
-    } else if (arcRole.contains("summation") || arcRole.contains("calculation")) {
-      return "calculation";
-    } else if (arcRole.contains("dimension") || arcRole.contains("definition")) {
-      return "definition";
-    }
 
-    return "other";
+  private static final String XLINK_NS = "http://www.w3.org/1999/xlink";
+  private static final String XBRLDT_NS = "http://xbrl.org/2005/xbrldt";
+
+  /** Linkbase file suffix to the linkbase_type it produces. */
+  private static final Map<String, String> LINKBASE_SUFFIXES = new LinkedHashMap<String, String>();
+
+  static {
+    LINKBASE_SUFFIXES.put("_pre.xml", "presentation");
+    LINKBASE_SUFFIXES.put("_cal.xml", "calculation");
+    LINKBASE_SUFFIXES.put("_def.xml", "definition");
   }
 
   /**
-   * Clean concept name by removing namespace prefix.
+   * Extracts relationships from the filing's presentation, calculation and definition linkbases.
+   *
+   * <p>Relationships live in linkbase files sitting beside the filing, not inside the document
+   * itself, so a converter reading only the downloaded document finds none and writes nothing. The
+   * effect is invisible: the filing is recorded as processed and the table simply has no rows for
+   * it. Measured on 2021, 4,846 of 22,567 annual and quarterly filings were in that state, and
+   * reprocessing closed 5% of them because no amount of re-reading the same document can produce
+   * what was never in it.
+   *
+   * <p>Concepts are named {@code prefix:LocalName} to match the {@code concept} column of
+   * financial_line_items, so the two tables join. The locator href gives {@code prefix_LocalName},
+   * because an XML id cannot contain a colon.
+   *
+   * @return the number of relationships appended to {@code dataList}
    */
-  private String cleanConceptName(String concept) {
-    if (concept == null) return null;
-    if (concept.contains(":")) {
-      return concept.substring(concept.indexOf(":") + 1);
-    }
-    return concept;
-  }
+  int extractLinkbaseRelationships(String cik, String accession, String filingDate,
+      List<Map<String, Object>> dataList) {
+    String cikNumeric = cik.replaceFirst("^0+", "");
+    String baseUrl = String.format(Locale.ROOT,
+        "https://www.sec.gov/Archives/edgar/data/%s/%s", cikNumeric, accession.replace("-", ""));
 
-  /**
-   * Extract relationships from inline XBRL structure.
-   */
-  private void extractInlineXBRLRelationships(Document doc,
-      java.util.List<org.apache.calcite.adapter.file.partition.PartitionedTableConfig.TableColumn> columns,
-      List<Map<String, Object>> dataList, String cik, String accession, String filingDate, String sourcePath) {
-
-    String fileName = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
-    LOGGER.debug(" extractInlineXBRLRelationships START");
-    LOGGER.debug(String.format("DEBUG: Document is null? %s", doc == null));
-    LOGGER.debug(String.format("DEBUG: Source file is: %s", fileName));
-
-    // First, try to download and parse external linkbase files
-    // These contain the actual relationship definitions for inline XBRL
-    try {
-      downloadAndParseLinkbases(sourcePath, columns, dataList, cik, accession, filingDate);
-    } catch (Exception e) {
-      LOGGER.debug("Failed to download/parse linkbase files: " + e.getMessage());
+    List<String> linkbaseFiles = listLinkbaseFiles(baseUrl);
+    if (linkbaseFiles.isEmpty()) {
+      return 0;
     }
 
-    // In inline XBRL, relationships are often implicit in the document structure
-    // We extract multiple types of relationships:
-    // 1. Parent-child from nesting
-    // 2. Calculation relationships from summation contexts
-    // 3. Dimensional relationships
-
-    // Track unique relationships to avoid duplicates
-    Set<String> processedRelationships = new HashSet<>();
-
-    // CRITICAL FIX: The doc passed here is a transformed document that doesn't contain
-    // ix:relationship or ix:footnote elements. We need to parse the original HTML file
-    // to find these inline XBRL relationship elements.
-    Document originalHtmlDoc = null;
-    String filename = sourcePath.substring(sourcePath.lastIndexOf('/') + 1);
-    if (filename.endsWith(".htm") || filename.endsWith(".html")) {
+    int year = 0;
+    if (filingDate != null && filingDate.length() >= 4) {
       try {
-        LOGGER.debug("Parsing original HTML file to extract inline XBRL relationships: " + filename);
-        DocumentBuilder builder = newSafeDocumentBuilder(true);
-        try (InputStream is = sanitizeXmlStream(storageProvider.openInputStream(sourcePath))) {
-          originalHtmlDoc = builder.parse(is);
-        }
-        LOGGER.debug("Successfully parsed original HTML file for relationship extraction");
-      } catch (org.xml.sax.SAXParseException e) {
-        LOGGER.info("Strict XML parse failed for {} relationships: {} — falling back to JSoup",
-            filename, e.getMessage());
-        originalHtmlDoc = parseWithJsoupFallback(sourcePath);
-      } catch (Exception e) {
-        LOGGER.warn("Failed to parse original HTML file for relationships: " + e.getMessage());
+        year = Integer.parseInt(filingDate.substring(0, 4));
+      } catch (NumberFormatException e) {
+        LOGGER.debug("Unparseable filing date {} for {}", filingDate, accession);
       }
     }
 
-    // Use the original HTML document if available, otherwise fall back to the transformed doc
-    Document searchDoc = (originalHtmlDoc != null) ? originalHtmlDoc : doc;
-
-    // Look for ix:relationship elements (Inline XBRL 1.1 standard)
-    NodeList ixRelationships = searchDoc.getElementsByTagNameNS("http://www.xbrl.org/2013/inlineXBRL", "relationship");
-    LOGGER.debug(String.format("Found %d ix:relationship elements", ixRelationships.getLength()));
-
-    for (int i = 0; i < ixRelationships.getLength(); i++) {
-      Element ixRel = (Element) ixRelationships.item(i);
-      String arcrole = ixRel.getAttribute("arcrole");
-      String fromRefs = ixRel.getAttribute("fromRefs");  // FIXED: Use correct plural attribute
-      String toRefs = ixRel.getAttribute("toRefs");      // FIXED: Use correct plural attribute
-      String order = ixRel.getAttribute("order");
-      String weight = ixRel.getAttribute("weight");
-
-      LOGGER.debug(
-          String.format("Processing ix:relationship %d: arcrole=%s, fromRefs=%s, toRefs=%s",
-          i, arcrole, fromRefs, toRefs));
-
-      if (arcrole != null && !arcrole.isEmpty() && fromRefs != null && !fromRefs.isEmpty() &&
-          toRefs != null && !toRefs.isEmpty()) {
-
-        // Split space-separated fromRefs and toRefs (inline XBRL can have multiple refs)
-        String[] fromRefArray = fromRefs.trim().split("\\s+");
-        String[] toRefArray = toRefs.trim().split("\\s+");
-
-        // Create relationships for each fromRef to each toRef combination
-        for (String fromRef : fromRefArray) {
-          for (String toRef : toRefArray) {
-            String relationshipKey = fromRef + "->" + toRef + ":" + arcrole;
-
-            if (!processedRelationships.contains(relationshipKey)) {
-              Map<String, Object> data = new HashMap<>();
-              data.put("cik", cik);
-              data.put("accession_number", accession);
-              data.put("filing_date", filingDate);
-              data.put("year", extractYearFromDate(filingDate));
-              data.put("linkbase_type", determineLinkbaseType(arcrole));
-              data.put("arc_role", arcrole);
-              Node ixRelParent = ixRel.getParentNode();
-              String ixRelLinkRole = null;
-              if (ixRelParent instanceof Element) {
-                Element ixRelParentLink = (Element) ixRelParent;
-                ixRelLinkRole = ixRelParentLink.getAttribute("xlink:role");
-                if (ixRelLinkRole == null || ixRelLinkRole.isEmpty()) {
-                  ixRelLinkRole = ixRelParentLink.getAttribute("role");
-                }
-              }
-              data.put("link_role", ixRelLinkRole);
-              data.put("from_concept", cleanConceptName(fromRef));
-              data.put("to_concept", cleanConceptName(toRef));
-              data.put("weight", weight != null && !weight.isEmpty() ? Double.parseDouble(weight) : null);
-              data.put("order", order != null && !order.isEmpty() ? (int) Double.parseDouble(order) : i);
-              data.put("preferred_label", ixRel.getAttribute("preferredLabel"));
-              dataList.add(data);
-              processedRelationships.add(relationshipKey);
-              LOGGER.debug("Added ix:relationship: " + relationshipKey);
-            }
-          }
-        }
-      } else {
-        LOGGER.debug(
-            String.format("Skipping ix:relationship %d: missing required attributes (arcrole=%s, fromRefs=%s, toRefs=%s)",
-            i, arcrole, fromRefs, toRefs));
-      }
-    }
-
-    // Look for ix:footnote elements tied to facts
-    NodeList ixFootnotes = searchDoc.getElementsByTagNameNS("http://www.xbrl.org/2013/inlineXBRL", "footnote");
-    LOGGER.debug(String.format("Found %d ix:footnote elements", ixFootnotes.getLength()));
-
-    for (int i = 0; i < ixFootnotes.getLength(); i++) {
-      Element footnote = (Element) ixFootnotes.item(i);
-      String footnoteRole = footnote.getAttribute("footnoteRole");
-      String id = footnote.getAttribute("id");
-
-      if (id != null && !id.isEmpty()) {
-        // Look for elements that reference this footnote
-        NodeList allElems = searchDoc.getElementsByTagName("*");
-        for (int j = 0; j < allElems.getLength(); j++) {
-          Element elem = (Element) allElems.item(j);
-          String footnoteRefs = elem.getAttribute("footnoteRefs");
-
-          if (footnoteRefs != null && footnoteRefs.contains(id)) {
-            String concept = extractConceptName(elem);
-            if (concept != null) {
-              String relationshipKey = concept + "-footnote->" + id;
-
-              if (!processedRelationships.contains(relationshipKey)) {
-                Map<String, Object> data = new HashMap<>();
-                data.put("cik", cik);
-                data.put("accession_number", accession);
-                data.put("filing_date", filingDate);
-                data.put("year", extractYearFromDate(filingDate));
-                data.put("linkbase_type", "reference");
-                data.put("arc_role", "http://www.xbrl.org/2009/arcrole/fact-explanatoryFact");
-                Node footnoteParent = footnote.getParentNode();
-                String footnoteLinkRole = null;
-                if (footnoteParent instanceof Element) {
-                  Element footnoteParentLink = (Element) footnoteParent;
-                  footnoteLinkRole = footnoteParentLink.getAttribute("xlink:role");
-                  if (footnoteLinkRole == null || footnoteLinkRole.isEmpty()) {
-                    footnoteLinkRole = footnoteParentLink.getAttribute("role");
-                  }
-                }
-                data.put("link_role", footnoteLinkRole);
-                data.put("from_concept", cleanConceptName(concept));
-                data.put("to_concept", "footnote_" + id);
-                data.put("weight", null);
-                data.put("order", i * 1000 + j);
-                data.put("preferred_label", footnoteRole);
-                dataList.add(data);
-                processedRelationships.add(relationshipKey);
-                LOGGER.debug("Added fact-footnote relationship: " + relationshipKey);
-              }
-            }
-          }
+    int extracted = 0;
+    for (String name : linkbaseFiles) {
+      String linkbaseType = null;
+      for (Map.Entry<String, String> entry : LINKBASE_SUFFIXES.entrySet()) {
+        if (name.toLowerCase(Locale.ROOT).endsWith(entry.getKey())) {
+          linkbaseType = entry.getValue();
         }
       }
-    }
-
-    // Look for ix:nonNumeric and ix:nonFraction elements that define structure
-    NodeList ixElements = doc.getElementsByTagNameNS("http://www.xbrl.org/2013/inlineXBRL", "*");
-    LOGGER.debug(String.format("Found %d inline XBRL elements", ixElements.getLength()));
-
-    // Extract relationships from table structures (common in inline XBRL)
-    NodeList tables = doc.getElementsByTagName("table");
-    for (int t = 0; t < tables.getLength(); t++) {
-      Element table = (Element) tables.item(t);
-
-      // Look for XBRL concepts within table rows
-      NodeList rows = table.getElementsByTagName("tr");
-      String lastParentConcept = null;
-
-      for (int r = 0; r < rows.getLength(); r++) {
-        NodeList cells = ((Element) rows.item(r)).getElementsByTagName("*");
-
-        for (int c = 0; c < cells.getLength(); c++) {
-          Element cell = (Element) cells.item(c);
-
-          if (cell.hasAttribute("contextRef") || cell.hasAttribute("name")) {
-            String concept = extractConceptName(cell);
-            if (concept != null) {
-              // Check if this appears to be a child of the previous concept
-              if (lastParentConcept != null && !concept.equals(lastParentConcept)) {
-                String relationshipKey = lastParentConcept + "->" + concept;
-
-                if (!processedRelationships.contains(relationshipKey)) {
-                  Map<String, Object> data = new HashMap<>();
-                  data.put("cik", cik);
-                  data.put("accession_number", accession);
-                  data.put("filing_date", filingDate);
-                  data.put("year", extractYearFromDate(filingDate));
-                  data.put("linkbase_type", "presentation");
-                  data.put("arc_role", "table-structure");
-                  Node cellParent = cell.getParentNode();
-                  String cellLinkRole = null;
-                  if (cellParent instanceof Element) {
-                    Element cellParentLink = (Element) cellParent;
-                    cellLinkRole = cellParentLink.getAttribute("xlink:role");
-                    if (cellLinkRole == null || cellLinkRole.isEmpty()) {
-                      cellLinkRole = cellParentLink.getAttribute("role");
-                    }
-                  }
-                  data.put("link_role", cellLinkRole);
-                  data.put("from_concept", cleanConceptName(lastParentConcept));
-                  data.put("to_concept", cleanConceptName(concept));
-                  data.put("weight", null);
-                  data.put("order", r * 100 + c);  // Row-column based ordering
-                  data.put("preferred_label", cell.getAttribute("preferredLabel"));
-                  dataList.add(data);
-                  processedRelationships.add(relationshipKey);
-                }
-              }
-
-              // Update parent if this looks like a section header
-              if (cell.getTagName().matches("th|h\\d") ||
-                  cell.getAttribute("class").contains("header")) {
-                lastParentConcept = concept;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    // Extract calculation relationships from elements with calculation attributes
-    NodeList allElements = doc.getElementsByTagName("*");
-    for (int i = 0; i < allElements.getLength(); i++) {
-      Element element = (Element) allElements.item(i);
-
-      // Look for calculation weight indicators
-      if (element.hasAttribute("calculationWeight") ||
-          element.hasAttribute("data-calculation-parent")) {
-        String concept = extractConceptName(element);
-        String parentConcept = element.getAttribute("data-calculation-parent");
-        String weight = element.getAttribute("calculationWeight");
-
-        if (concept != null && parentConcept != null && !parentConcept.isEmpty()) {
-          String relationshipKey = parentConcept + "-calc->" + concept;
-
-          if (!processedRelationships.contains(relationshipKey)) {
-            Map<String, Object> data = new HashMap<>();
-            data.put("cik", cik);
-            data.put("accession_number", accession);
-            data.put("filing_date", filingDate);
-            data.put("year", extractYearFromDate(filingDate));
-            data.put("linkbase_type", "calculation");
-            data.put("arc_role", "summation-item");
-            Node elementParent = element.getParentNode();
-            String elementLinkRole = null;
-            if (elementParent instanceof Element) {
-              Element elementParentLink = (Element) elementParent;
-              elementLinkRole = elementParentLink.getAttribute("xlink:role");
-              if (elementLinkRole == null || elementLinkRole.isEmpty()) {
-                elementLinkRole = elementParentLink.getAttribute("role");
-              }
-            }
-            data.put("link_role", elementLinkRole);
-            data.put("from_concept", cleanConceptName(parentConcept));
-            data.put("to_concept", cleanConceptName(concept));
-            data.put("weight", weight.isEmpty() ? 1.0 : Double.parseDouble(weight));
-            data.put("order", i);
-            data.put("preferred_label", element.getAttribute("preferredLabel"));
-            dataList.add(data);
-            processedRelationships.add(relationshipKey);
-          }
-        }
-      }
-    }
-
-    LOGGER.debug(String.format("Extracted %d unique inline XBRL relationships", processedRelationships.size()));
-  }
-
-  /**
-   * Download and parse linkbase files referenced from inline XBRL schema.
-   */
-  private void downloadAndParseLinkbases(String htmlPath,
-      java.util.List<org.apache.calcite.adapter.file.partition.PartitionedTableConfig.TableColumn> columns,
-      List<Map<String, Object>> dataList, String cik, String accession, String filingDate) throws Exception {
-
-    LOGGER.debug("Looking for linkbase references in inline XBRL document");
-
-    // Parse the HTML file to look for schema references
-    LOGGER.debug("Parsing HTML file for schema references: " + htmlPath);
-    Document doc;
-    try {
-      DocumentBuilder builder = newSafeDocumentBuilder(true);
-      try (InputStream is = storageProvider.openInputStream(htmlPath)) {
-        doc = builder.parse(is);
-      }
-      LOGGER.debug("Successfully parsed HTML file, proceeding with schema reference search");
-    } catch (Exception e) {
-      LOGGER.debug("Failed to parse HTML file: " + e.getMessage());
-      return;
-    }
-
-    // Find schemaRef element that points to XSD file
-    // First try with the correct linkbase namespace
-    NodeList schemaRefs = doc.getElementsByTagNameNS("http://www.xbrl.org/2003/linkbase", "schemaRef");
-    LOGGER.debug("Found " + schemaRefs.getLength() + " schemaRef elements in linkbase namespace");
-
-    if (schemaRefs.getLength() == 0) {
-      // Try with prefixed tag name (more common in inline XBRL)
-      schemaRefs = doc.getElementsByTagName("link:schemaRef");
-      LOGGER.debug("Found " + schemaRefs.getLength() + " link:schemaRef elements");
-    }
-    if (schemaRefs.getLength() == 0) {
-      // Try looking inside ix:references elements
-      NodeList references = doc.getElementsByTagName("ix:references");
-      LOGGER.debug("Found " + references.getLength() + " ix:references elements");
-      for (int i = 0; i < references.getLength(); i++) {
-        Element referencesEl = (Element) references.item(i);
-        NodeList childSchemaRefs = referencesEl.getElementsByTagName("link:schemaRef");
-        LOGGER.debug("Found " + childSchemaRefs.getLength() + " link:schemaRef children in ix:references[" + i + "]");
-        if (childSchemaRefs.getLength() > 0) {
-          schemaRefs = childSchemaRefs;
-          break;
-        }
-      }
-    }
-
-    if (schemaRefs.getLength() == 0) {
-      LOGGER.debug("No schemaRef found in inline XBRL - no linkbases to download");
-      return;
-    }
-
-    Element schemaRef = (Element) schemaRefs.item(0);
-    String xsdHref = schemaRef.getAttribute("xlink:href");
-    if (xsdHref == null || xsdHref.isEmpty()) {
-      xsdHref = schemaRef.getAttribute("href");
-    }
-
-    if (xsdHref == null || xsdHref.isEmpty()) {
-      LOGGER.debug("No XSD href found in schemaRef");
-      return;
-    }
-
-    LOGGER.debug("Found XSD reference: " + xsdHref);
-
-    // Extract base URL from source file path or document URL
-    String baseUrl = extractBaseUrl(htmlPath, xsdHref);
-    if (baseUrl == null) {
-      LOGGER.warn("Could not determine base URL for linkbase downloads");
-      return;
-    }
-
-    // Download and parse XSD to find linkbase references
-    String xsdUrl = resolveUrl(baseUrl, xsdHref);
-    LOGGER.debug("Downloading XSD from: " + xsdUrl);
-
-    String xsdContent = downloadFile(xsdUrl);
-    if (xsdContent == null) {
-      LOGGER.debug("Failed to download XSD file from: " + xsdUrl + " - continuing with inline XBRL relationship processing");
-      // For inline XBRL documents, XSD files often don't exist on the server
-      // We can still extract relationships from the inline document structure
-      return;
-    }
-
-    // Parse XSD to find linkbaseRef elements
-    DocumentBuilder xsdBuilder = newSafeDocumentBuilder(true);
-    Document xsdDoc = xsdBuilder.parse(new ByteArrayInputStream(xsdContent.getBytes(StandardCharsets.UTF_8)));
-
-    // Find linkbaseRef elements
-    NodeList linkbaseRefs = xsdDoc.getElementsByTagNameNS("http://www.xbrl.org/2003/linkbase", "linkbaseRef");
-    if (linkbaseRefs.getLength() == 0) {
-      linkbaseRefs = xsdDoc.getElementsByTagName("link:linkbaseRef");
-    }
-
-    LOGGER.debug("Found " + linkbaseRefs.getLength() + " linkbase references in XSD");
-
-    // Fallback: linkbases embedded directly in the XSD (no linkbaseRef elements)
-    if (linkbaseRefs.getLength() == 0) {
-      boolean foundEmbedded = false;
-      String[] embeddedTypes = {"calculationLink", "presentationLink", "definitionLink"};
-      for (String linkType : embeddedTypes) {
-        NodeList embedded = xsdDoc.getElementsByTagNameNS("http://www.xbrl.org/2003/linkbase", linkType);
-        if (embedded.getLength() == 0) {
-          embedded = xsdDoc.getElementsByTagName("link:" + linkType);
-        }
-        if (embedded.getLength() > 0) {
-          foundEmbedded = true;
-          break;
-        }
-      }
-      if (foundEmbedded) {
-        LOGGER.debug("Detected linkbase arcs embedded directly in XSD — parsing XSD as linkbase document");
-        extractLinkbaseRelationships(xsdDoc, columns, dataList, cik, accession, filingDate, "mixed");
-        return;
-      }
-    }
-
-    // Process each linkbase file
-    for (int i = 0; i < linkbaseRefs.getLength(); i++) {
-      Element linkbaseRef = (Element) linkbaseRefs.item(i);
-      String linkbaseHref = linkbaseRef.getAttribute("xlink:href");
-      if (linkbaseHref == null || linkbaseHref.isEmpty()) {
-        linkbaseHref = linkbaseRef.getAttribute("href");
-      }
-
-      if (linkbaseHref == null || linkbaseHref.isEmpty()) {
+      if (linkbaseType == null) {
         continue;
       }
-
-      String role = linkbaseRef.getAttribute("xlink:role");
-      if (role == null || role.isEmpty()) {
-        role = linkbaseRef.getAttribute("role");
+      // index.json listed this file, so it exists. Anything else — a 404, an unreadable body, a
+      // linkbase that will not parse — is a genuine anomaly, and skipping it would write a
+      // partial relationship set that is indistinguishable from a complete one. Let it throw:
+      // the accession fails, is not recorded, and is offered again by the next run.
+      String body = downloadFile(baseUrl + "/" + name);
+      if (body == null) {
+        throw new IllegalStateException("Linkbase " + name + " is listed in index.json but could "
+            + "not be downloaded for accession " + accession);
       }
+      Document linkbase;
+      try {
+        linkbase = newSafeDocumentBuilder(true).parse(
+            new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not parse linkbase " + name + " for accession "
+            + accession, e);
+      }
+      extracted += readExtendedLinks(linkbase, linkbaseType, cik, accession, filingDate, year,
+          dataList);
+    }
+    return extracted;
+  }
 
-      // Determine linkbase type from role
-      String linkbaseType = determineLinkbaseTypeFromRole(role);
+  /** Names the presentation, calculation and definition linkbases sitting beside a filing. */
+  private List<String> listLinkbaseFiles(String baseUrl) {
+    // An empty list must mean "this filing publishes no linkbases", never "the listing could not
+    // be read". Conflating the two writes an empty relationship set for a filing that has one,
+    // and records the filing as complete — the failure then looks exactly like a filing that
+    // legitimately had nothing, which is undiagnosable after the fact.
+    String body = downloadFile(baseUrl + "/index.json");
+    if (body == null) {
+      throw new IllegalStateException("Could not list filing directory " + baseUrl
+          + " to find its linkbases");
+    }
+    List<String> found = new ArrayList<String>();
+    try {
+      com.fasterxml.jackson.databind.JsonNode items =
+          new com.fasterxml.jackson.databind.ObjectMapper().readTree(body)
+              .path("directory").path("item");
+      for (com.fasterxml.jackson.databind.JsonNode item : items) {
+        String name = item.path("name").asText("");
+        String lower = name.toLowerCase(Locale.ROOT);
+        for (String suffix : LINKBASE_SUFFIXES.keySet()) {
+          if (lower.endsWith(suffix)) {
+            found.add(name);
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not read the directory listing for " + baseUrl, e);
+    }
+    return found;
+  }
 
-      LOGGER.debug("Processing " + linkbaseType + " linkbase: " + linkbaseHref);
-
-      // Download linkbase file
-      String linkbaseUrl = resolveUrl(baseUrl, linkbaseHref);
-      String linkbaseContent = downloadFile(linkbaseUrl);
-
-      if (linkbaseContent == null) {
-        LOGGER.warn("Failed to download linkbase from: " + linkbaseUrl);
+  /**
+   * Reads every extended link in one linkbase, appending its arcs as relationship rows.
+   *
+   * <p>An arc names its endpoints by locator label, not by concept, and those labels are scoped to
+   * the extended link that declares them — the same label means different concepts in two links of
+   * the same file. The locator map is therefore rebuilt per link rather than per file.
+   */
+  int readExtendedLinks(Document linkbase, String linkbaseType, String cik,
+      String accession, String filingDate, int year, List<Map<String, Object>> dataList) {
+    int extracted = 0;
+    NodeList links = linkbase.getDocumentElement().getChildNodes();
+    for (int i = 0; i < links.getLength(); i++) {
+      if (links.item(i).getNodeType() != Node.ELEMENT_NODE) {
         continue;
       }
+      Element link = (Element) links.item(i);
+      if (!localName(link).endsWith("Link")) {
+        continue;
+      }
+      String linkRole = link.getAttributeNS(XLINK_NS, "role");
 
-      // Parse linkbase and extract relationships
-      try {
-        DocumentBuilder linkbaseBuilder = newSafeDocumentBuilder(true);
-        Document linkbaseDoc = linkbaseBuilder.parse(new ByteArrayInputStream(linkbaseContent.getBytes(StandardCharsets.UTF_8)));
-        extractLinkbaseRelationships(linkbaseDoc, columns, dataList, cik, accession, filingDate, linkbaseType);
-      } catch (Exception e) {
-        LOGGER.warn("Failed to parse linkbase " + linkbaseHref + ": " + e.getMessage());
+      Map<String, String> locators = new HashMap<String, String>();
+      NodeList children = link.getChildNodes();
+      for (int j = 0; j < children.getLength(); j++) {
+        if (children.item(j).getNodeType() != Node.ELEMENT_NODE) {
+          continue;
+        }
+        Element child = (Element) children.item(j);
+        if ("loc".equals(localName(child))) {
+          locators.put(child.getAttributeNS(XLINK_NS, "label"),
+              conceptFromHref(child.getAttributeNS(XLINK_NS, "href")));
+        }
+      }
+
+      for (int j = 0; j < children.getLength(); j++) {
+        if (children.item(j).getNodeType() != Node.ELEMENT_NODE) {
+          continue;
+        }
+        Element arc = (Element) children.item(j);
+        if (!localName(arc).endsWith("Arc")) {
+          continue;
+        }
+        String from = locators.get(arc.getAttributeNS(XLINK_NS, "from"));
+        String to = locators.get(arc.getAttributeNS(XLINK_NS, "to"));
+        if (from == null || to == null) {
+          // An arc whose endpoints are resources rather than locators — a label or reference arc.
+          // Its target is documentation, not a concept, so it is not a relationship between two
+          // concepts and from_concept/to_concept could not be honestly filled.
+          continue;
+        }
+
+        Map<String, Object> data = new HashMap<String, Object>();
+        data.put("cik", cik);
+        data.put("accession_number", accession);
+        data.put("filing_date", filingDate);
+        data.put("year", year);
+        data.put("linkbase_type", linkbaseType);
+        data.put("arc_role", arc.getAttributeNS(XLINK_NS, "arcrole"));
+        data.put("link_role", emptyToNull(linkRole));
+        data.put("from_concept", from);
+        data.put("to_concept", to);
+        data.put("weight", parseDoubleOrNull(arc.getAttribute("weight")));
+        data.put("order", parseDoubleOrNull(arc.getAttribute("order")));
+        data.put("preferred_label", emptyToNull(arc.getAttribute("preferredLabel")));
+        data.put("arc_use", emptyToNull(arc.getAttribute("use")));
+        Double priority = parseDoubleOrNull(arc.getAttribute("priority"));
+        data.put("arc_priority", priority == null ? null : Integer.valueOf(priority.intValue()));
+        data.put("context_element",
+            emptyToNull(arc.getAttributeNS(XBRLDT_NS, "contextElement")));
+        String closed = arc.getAttributeNS(XBRLDT_NS, "closed");
+        data.put("closed", closed == null || closed.isEmpty() ? null : Boolean.valueOf(closed));
+
+        dataList.add(data);
+        extracted++;
       }
     }
+    return extracted;
+  }
+
+  /** Local name of an element, whether or not the parser resolved its namespace. */
+  private static String localName(Element element) {
+    String local = element.getLocalName();
+    if (local != null) {
+      return local;
+    }
+    String name = element.getNodeName();
+    int colon = name.indexOf(':');
+    return colon < 0 ? name : name.substring(colon + 1);
   }
 
   /**
-   * Extract relationships from a linkbase document.
+   * Turns a locator href into a concept name.
+   *
+   * <p>{@code us-gaap-2021.xsd#us-gaap_Assets} names the concept {@code us-gaap:Assets}. The
+   * fragment separates prefix from local name with an underscore because an XML id cannot contain
+   * a colon; the first underscore is the separator, and any later one belongs to the local name.
    */
-  private void extractLinkbaseRelationships(Document linkbaseDoc,
-      java.util.List<org.apache.calcite.adapter.file.partition.PartitionedTableConfig.TableColumn> columns,
-      List<Map<String, Object>> dataList, String cik, String accession, String filingDate, String linkbaseType) {
-
-    // Find arc elements in the linkbase
-    NodeList arcs = linkbaseDoc.getElementsByTagName("*");
-    int relationshipCount = 0;
-
-    for (int i = 0; i < arcs.getLength(); i++) {
-      Element element = (Element) arcs.item(i);
-      String tagName = element.getTagName();
-
-      // Look for arc elements (calculationArc, presentationArc, definitionArc, etc.)
-      if (tagName.endsWith("Arc") || tagName.contains(":arc")) {
-        String from = element.getAttribute("xlink:from");
-        String to = element.getAttribute("xlink:to");
-
-        if (from == null || from.isEmpty()) {
-          from = element.getAttribute("from");
-        }
-        if (to == null || to.isEmpty()) {
-          to = element.getAttribute("to");
-        }
-
-        if (from != null && !from.isEmpty() && to != null && !to.isEmpty()) {
-          Map<String, Object> data = new HashMap<>();
-          data.put("cik", cik);
-          data.put("accession_number", accession);
-          data.put("filing_date", filingDate);
-          data.put("year", extractYearFromDate(filingDate));
-          data.put("linkbase_type", linkbaseType);
-
-          // Get arc role
-          String arcRole = element.getAttribute("xlink:arcrole");
-          if (arcRole == null || arcRole.isEmpty()) {
-            arcRole = element.getAttribute("arcrole");
-          }
-          data.put("arc_role", arcRole);
-          Node linkbaseArcParent = element.getParentNode();
-          String linkbaseArcLinkRole = null;
-          if (linkbaseArcParent instanceof Element) {
-            Element linkbaseArcParentLink = (Element) linkbaseArcParent;
-            linkbaseArcLinkRole = linkbaseArcParentLink.getAttribute("xlink:role");
-            if (linkbaseArcLinkRole == null || linkbaseArcLinkRole.isEmpty()) {
-              linkbaseArcLinkRole = linkbaseArcParentLink.getAttribute("role");
-            }
-          }
-          data.put("link_role", linkbaseArcLinkRole);
-
-          // Clean concept names
-          data.put("from_concept", cleanConceptName(from));
-          data.put("to_concept", cleanConceptName(to));
-
-          // Get weight for calculation linkbase
-          String weight = element.getAttribute("weight");
-          if (weight != null && !weight.isEmpty()) {
-            try {
-              data.put("weight", Double.parseDouble(weight));
-            } catch (NumberFormatException e) {
-              data.put("weight", null);
-            }
-          } else {
-            data.put("weight", null);
-          }
-
-          // Get order for presentation linkbase
-          String order = element.getAttribute("order");
-          if (order != null && !order.isEmpty()) {
-            try {
-              data.put("order", (int) Double.parseDouble(order));
-            } catch (NumberFormatException e) {
-              data.put("order", null);
-            }
-          } else {
-            data.put("order", null);
-          }
-
-          // Get preferred label
-          String preferredLabel = element.getAttribute("preferredLabel");
-          data.put("preferred_label", preferredLabel);
-
-          dataList.add(data);
-          relationshipCount++;
-        }
-      }
+  static String conceptFromHref(String href) {
+    if (href == null || href.isEmpty()) {
+      return null;
     }
-
-    LOGGER.debug("Extracted " + relationshipCount + " relationships from " + linkbaseType + " linkbase");
+    String fragment = href.substring(href.indexOf('#') + 1);
+    int separator = fragment.indexOf('_');
+    if (separator <= 0) {
+      return fragment;
+    }
+    return fragment.substring(0, separator) + ":" + fragment.substring(separator + 1);
   }
 
-  /**
-   * Determine linkbase type from role URI.
-   */
-  private String determineLinkbaseTypeFromRole(String role) {
-    if (role == null) return "unknown";
-
-    if (role.contains("calculation")) {
-      return "calculation";
-    } else if (role.contains("presentation")) {
-      return "presentation";
-    } else if (role.contains("definition")) {
-      return "definition";
-    } else if (role.contains("label")) {
-      return "label";
-    } else if (role.contains("reference")) {
-      return "reference";
-    }
-
-    return "other";
+  private static String emptyToNull(String value) {
+    return value == null || value.isEmpty() ? null : value;
   }
+
+
+
+
 
   /**
    * Extract base URL from file path or filing information.

--- a/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/XbrlToParquetConverter.java
+++ b/govdata/src/main/java/org/apache/calcite/adapter/govdata/sec/XbrlToParquetConverter.java
@@ -565,9 +565,9 @@ public class XbrlToParquetConverter implements FileConverter {
 
   private String extractFilingType(Document doc, String sourcePath) {
     // For ownership documents (Form 3/4/5), extract documentType
-    NodeList docTypes = doc.getElementsByTagName("documentType");
-    if (docTypes.getLength() > 0) {
-      String docType = docTypes.item(0).getTextContent().trim();
+    String documentType = firstTextByLocalName(doc, "documentType");
+    if (documentType != null) {
+      String docType = documentType;
       // Return just the number for forms 3, 4, 5
       if (docType.equals("3") || docType.equals("4") || docType.equals("5")) {
         return docType;
@@ -585,11 +585,10 @@ public class XbrlToParquetConverter implements FileConverter {
       return docType.replace("-", "");
     }
 
-    // Also check for dei:DocumentType (common in inline XBRL)
-    NodeList deiDocTypes = doc.getElementsByTagName("dei:DocumentType");
-    if (deiDocTypes.getLength() > 0) {
-      String docType = deiDocTypes.item(0).getTextContent().trim();
-      return docType.replace("-", "");
+    // DocumentType, whether the filer prefixed it or not.
+    String deiDocType = firstTextByLocalName(doc, "DocumentType");
+    if (deiDocType != null) {
+      return deiDocType.replace("-", "");
     }
 
     // Also check with ix: prefix for inline XBRL (note the capital N in nonNumeric)
@@ -757,14 +756,13 @@ public class XbrlToParquetConverter implements FileConverter {
       }
     }
 
-    // Try to extract from dei:DocumentPeriodEndDate (inline XBRL)
-    NodeList deiPeriodEnds = doc.getElementsByTagNameNS("*", "dei:DocumentPeriodEndDate");
-    if (deiPeriodEnds.getLength() == 0) {
-      // Try without namespace prefix
-      deiPeriodEnds = doc.getElementsByTagName("dei:DocumentPeriodEndDate");
-    }
-    if (deiPeriodEnds.getLength() > 0) {
-      String date = deiPeriodEnds.item(0).getTextContent().trim();
+    // DocumentPeriodEndDate, however the filer spelled the tag. The previous attempt passed the
+    // qualified name "dei:DocumentPeriodEndDate" as a local name to getElementsByTagNameNS, which
+    // no element can match, so only the prefixed form was ever found and an unprefixed one was
+    // missed.
+    String deiPeriodEnd = firstTextByLocalName(doc, "DocumentPeriodEndDate");
+    if (deiPeriodEnd != null) {
+      String date = deiPeriodEnd;
       if (date.matches("\\d{4}-\\d{2}-\\d{2}")) {
         return date;
       }
@@ -790,26 +788,14 @@ public class XbrlToParquetConverter implements FileConverter {
     // Cap at current year to avoid picking up forward-looking dates from XBRL contexts
     // (e.g., lease/debt maturities extending years into the future).
     int maxYear = java.time.Year.now().getValue();
-    NodeList contexts = doc.getElementsByTagName("xbrli:context");
-    if (contexts.getLength() == 0) {
-      contexts = doc.getElementsByTagNameNS("*", "context");
-    }
-    if (contexts.getLength() == 0) {
-      contexts = doc.getElementsByTagName("context");
-    }
+    List<Element> contexts = elementsByLocalName(doc, "context");
 
     // Look for the latest valid period end date in contexts, capped at current year
     String latestDate = null;
-    for (int i = 0; i < contexts.getLength(); i++) {
-      Node context = contexts.item(i);
-
-      // Check for xbrli:endDate elements (common in inline XBRL like DEF 14A)
-      NodeList endDates = ((Element) context).getElementsByTagName("xbrli:endDate");
-      if (endDates.getLength() == 0) {
-        endDates = ((Element) context).getElementsByTagNameNS("*", "endDate");
-      }
-      if (endDates.getLength() > 0) {
-        String date = endDates.item(0).getTextContent().trim();
+    for (Element context : contexts) {
+      String endDate = firstTextByLocalName(context, "endDate");
+      if (endDate != null) {
+        String date = endDate;
         if (date.matches("\\d{4}-\\d{2}-\\d{2}")
             && Integer.parseInt(date.substring(0, 4)) <= maxYear) {
           if (latestDate == null || date.compareTo(latestDate) > 0) {
@@ -819,12 +805,9 @@ public class XbrlToParquetConverter implements FileConverter {
       }
 
       // Also check for instant dates
-      NodeList instants = ((Element) context).getElementsByTagName("xbrli:instant");
-      if (instants.getLength() == 0) {
-        instants = ((Element) context).getElementsByTagNameNS("*", "instant");
-      }
-      if (instants.getLength() > 0) {
-        String date = instants.item(0).getTextContent().trim();
+      String instant = firstTextByLocalName(context, "instant");
+      if (instant != null) {
+        String date = instant;
         if (date.matches("\\d{4}-\\d{2}-\\d{2}")
             && Integer.parseInt(date.substring(0, 4)) <= maxYear) {
           if (latestDate == null || date.compareTo(latestDate) > 0) {
@@ -931,26 +914,14 @@ public class XbrlToParquetConverter implements FileConverter {
 
     // Build context period map for joining period dates onto facts
     Map<String, Map<String, Object>> contextPeriodMap = new HashMap<>();
-    NodeList ctxNodes = doc.getElementsByTagName("context");
-    if (ctxNodes.getLength() == 0) {
-      ctxNodes = doc.getElementsByTagNameNS("*", "context");
-    }
-    for (int c = 0; c < ctxNodes.getLength(); c++) {
-      Node ctxNode = ctxNodes.item(c);
-      if (!(ctxNode instanceof Element)) continue;
-      Element ctxElement = (Element) ctxNode;
+    List<Element> ctxNodes = elementsByLocalName(doc, "context");
+    for (Element ctxElement : ctxNodes) {
       String id = ctxElement.getAttribute("id");
       if (id == null || id.isEmpty()) continue;
-      NodeList starts = ctxElement.getElementsByTagNameNS("*", "startDate");
-      if (starts.getLength() == 0) starts = ctxElement.getElementsByTagName("startDate");
-      NodeList ends = ctxElement.getElementsByTagNameNS("*", "endDate");
-      if (ends.getLength() == 0) ends = ctxElement.getElementsByTagName("endDate");
-      NodeList instants = ctxElement.getElementsByTagNameNS("*", "instant");
-      if (instants.getLength() == 0) instants = ctxElement.getElementsByTagName("instant");
       Map<String, Object> cp = new HashMap<>();
-      cp.put("period_start", starts.getLength() > 0 ? starts.item(0).getTextContent().trim() : null);
-      cp.put("period_end", ends.getLength() > 0 ? ends.item(0).getTextContent().trim() : null);
-      cp.put("is_instant", instants.getLength() > 0);
+      cp.put("period_start", firstTextByLocalName(ctxElement, "startDate"));
+      cp.put("period_end", firstTextByLocalName(ctxElement, "endDate"));
+      cp.put("is_instant", !elementsByLocalName(ctxElement, "instant").isEmpty());
       contextPeriodMap.put(id, cp);
     }
 
@@ -1500,22 +1471,10 @@ public class XbrlToParquetConverter implements FileConverter {
         }
       }
 
-      // Try without namespace
-      nodes = doc.getElementsByTagName(tag);
-      if (nodes.getLength() > 0) {
-        String text = nodes.item(0).getTextContent();
-        if (text != null && !text.trim().isEmpty()) {
-          return text.trim();
-        }
-      }
-
-      // Try with dei: prefix
-      nodes = doc.getElementsByTagName("dei:" + tag);
-      if (nodes.getLength() > 0) {
-        String text = nodes.item(0).getTextContent();
-        if (text != null && !text.trim().isEmpty()) {
-          return text.trim();
-        }
+      // Whatever prefix the filer used, or none.
+      String text = firstTextByLocalName(doc, tag);
+      if (text != null && !text.isEmpty()) {
+        return text;
       }
     }
     return null;
@@ -1563,16 +1522,17 @@ public class XbrlToParquetConverter implements FileConverter {
     java.util.List<org.apache.calcite.adapter.file.partition.PartitionedTableConfig.TableColumn> columns =
         AbstractSecDataDownloader.loadTableColumns("filing_contexts");
 
-    // Extract context elements
-    // Use getElementsByTagName (not getElementsByTagNameNS) because inline XBRL parsing
-    // creates context elements without a namespace, and some DOM implementations don't
-    // return null-namespace elements when using getElementsByTagNameNS("*", ...)
+    // A traditional XBRL instance writes <xbrli:context>; only once inline XBRL has been
+    // flattened does it become <context>. Matching the bare name alone — which this did — skips
+    // every prefixed filing and writes no contexts for it, while still recording the filing as
+    // processed. The elements *inside* each context were already read by local name here, so a
+    // filing either yielded all of its contexts or none of them, and which one depended on how
+    // the filer wrote the tag.
     List<Map<String, Object>> dataList = new ArrayList<>();
     Set<String> seenContextIds = new java.util.HashSet<>();
-    NodeList contexts = doc.getElementsByTagName("context");
+    List<Element> contexts = elementsByLocalName(doc, "context");
 
-    for (int i = 0; i < contexts.getLength(); i++) {
-      Element context = (Element) contexts.item(i);
+    for (Element context : contexts) {
       String contextId = context.getAttribute("id");
       if (!seenContextIds.add(contextId)) {
         continue;
@@ -1597,13 +1557,9 @@ public class XbrlToParquetConverter implements FileConverter {
       data.put("year", year);
       data.put("context_id", contextId);
 
-      // Extract entity information — try bare name first, then NS-wildcard
-      NodeList identifiers = context.getElementsByTagName("identifier");
-      if (identifiers.getLength() == 0) {
-        identifiers = context.getElementsByTagNameNS("*", "identifier");
-      }
-      if (identifiers.getLength() > 0) {
-        Element identifier = (Element) identifiers.item(0);
+      List<Element> identifiers = elementsByLocalName(context, "identifier");
+      if (!identifiers.isEmpty()) {
+        Element identifier = identifiers.get(0);
         data.put("entity_identifier", identifier.getTextContent());
         data.put("entity_scheme", identifier.getAttribute("scheme"));
       } else {
@@ -1612,26 +1568,13 @@ public class XbrlToParquetConverter implements FileConverter {
         data.put("entity_scheme", "http://www.sec.gov/CIK");
       }
 
-      // Extract period information — NS-wildcard first, bare-name fallback
-      NodeList startDates = context.getElementsByTagNameNS("*", "startDate");
-      if (startDates.getLength() == 0) startDates = context.getElementsByTagName("startDate");
-      NodeList endDates = context.getElementsByTagNameNS("*", "endDate");
-      if (endDates.getLength() == 0) endDates = context.getElementsByTagName("endDate");
-      NodeList instants = context.getElementsByTagNameNS("*", "instant");
-      if (instants.getLength() == 0) instants = context.getElementsByTagName("instant");
+      data.put("period_start", firstTextByLocalName(context, "startDate"));
+      data.put("period_end", firstTextByLocalName(context, "endDate"));
+      data.put("period_instant", firstTextByLocalName(context, "instant"));
 
-      data.put("period_start", startDates.getLength() > 0 ? startDates.item(0).getTextContent().trim() : null);
-      data.put("period_end", endDates.getLength() > 0 ? endDates.item(0).getTextContent().trim() : null);
-      data.put("period_instant", instants.getLength() > 0 ? instants.item(0).getTextContent().trim() : null);
-
-      // Extract segment and scenario (dimension members for segmented contexts)
-      NodeList segments = context.getElementsByTagNameNS("*", "segment");
-      if (segments.getLength() == 0) segments = context.getElementsByTagName("segment");
-      NodeList scenarios = context.getElementsByTagNameNS("*", "scenario");
-      if (scenarios.getLength() == 0) scenarios = context.getElementsByTagName("scenario");
-
-      data.put("segment", segments.getLength() > 0 ? segments.item(0).getTextContent().trim() : null);
-      data.put("scenario", scenarios.getLength() > 0 ? scenarios.item(0).getTextContent().trim() : null);
+      // Dimension members for segmented contexts.
+      data.put("segment", firstTextByLocalName(context, "segment"));
+      data.put("scenario", firstTextByLocalName(context, "scenario"));
 
       dataList.add(data);
     }
@@ -3244,27 +3187,12 @@ public class XbrlToParquetConverter implements FileConverter {
   }
 
   /**
-   * Write XBRL relationships to Parquet.
-   * Captures presentation, calculation, and definition linkbases.
+   * Writes a filing's presentation, calculation and definition relationships to Parquet.
    *
-   * NOTE: Modern SEC filings use inline XBRL (iXBRL) where relationships are not embedded
-   * in the main document but are provided in separate linkbase files (*.xml) referenced
-   * from the XSD schema. Since we currently only download the main HTML filing document,
-   * we cannot extract relationships from inline XBRL filings. This would require:
-   * 1. Downloading the XSD schema file referenced in the document
-   * 2. Parsing the XSD to find linkbase file references
-   * 3. Downloading and parsing each linkbase file (calculation, presentation, definition)
-   *
-   * For now, this method will create empty relationship files for inline XBRL to satisfy
-   * cache validation requirements.
-   *
-   * TODO: Implement full linkbase download functionality:
-   * - Extract XSD href from: <link:schemaRef xlink:type="simple" xlink:href="aapl-20230930.xsd">
-   * - Download XSD from: https://www.sec.gov/Archives/edgar/data/{CIK}/{ACCESSION}/{XSD_FILE}
-   * - Parse XSD for linkbaseRef elements pointing to linkbase files
-   * - Download each linkbase file (e.g., aapl-20230930_cal.xml, aapl-20230930_pre.xml)
-   * - Parse linkbase XML for arc elements defining relationships
-   * - Convert relationships to Parquet records with proper linkbase_type classification
+   * <p>Relationships are published in linkbase files sitting beside the filing, so they are
+   * fetched and read rather than sought inside the filing document — see
+   * {@link #extractLinkbaseRelationships}. The {@code doc} argument is retained for the caller's
+   * signature and is not read.
    */
   private void writeRelationshipsToParquet(Document doc, String outputPath,
       String cik, String accession, String filingType, String filingDate, String sourcePath) throws IOException {
@@ -3510,6 +3438,44 @@ public class XbrlToParquetConverter implements FileConverter {
       }
     }
     return extracted;
+  }
+
+  /**
+   * Elements with the given local name, whatever prefix or namespace the filing used.
+   *
+   * <p>An XBRL element is written {@code <xbrli:context>} in a traditional instance and
+   * {@code <context>} once inline XBRL has been flattened, and the two are different tags to
+   * {@link Document#getElementsByTagName}, which matches the qualified name. Asking for the bare
+   * name silently skips every prefixed filing; asking for the prefixed name skips every flattened
+   * one. Matching on the local name is indifferent to which the filer used.
+   *
+   * <p>{@code getElementsByTagNameNS("*", name)} looks like the answer but is not: it is unreliable
+   * for elements carrying no namespace at all, which is what the fallback parser produces, and it
+   * gives nothing when the document was parsed without namespace awareness. Reading the local name
+   * off each element works in all three cases.
+   */
+  static List<Element> elementsByLocalName(Node scope, String localName) {
+    NodeList all = scope instanceof Document
+        ? ((Document) scope).getElementsByTagName("*")
+        : ((Element) scope).getElementsByTagName("*");
+    List<Element> found = new ArrayList<Element>();
+    for (int i = 0; i < all.getLength(); i++) {
+      Element element = (Element) all.item(i);
+      if (localName.equals(localName(element))) {
+        found.add(element);
+      }
+    }
+    return found;
+  }
+
+  /** Text of the first element with this local name, or null when the filing has none. */
+  private static String firstTextByLocalName(Node scope, String localName) {
+    List<Element> found = elementsByLocalName(scope, localName);
+    if (found.isEmpty()) {
+      return null;
+    }
+    String text = found.get(0).getTextContent();
+    return text == null ? null : text.trim();
   }
 
   /** Local name of an element, whether or not the parser resolved its namespace. */

--- a/govdata/src/main/resources/ref/ref-schema.yaml
+++ b/govdata/src/main/resources/ref/ref-schema.yaml
@@ -4,6 +4,7 @@
 # Cross-referencing tables that link financial identifiers across systems:
 #   - GLEIF entities (LEI -> legal entity mapping)
 #   - GLEIF CIK mapping (LEI <-> SEC CIK bridge)
+#   - GLEIF relationships (LEI -> LEI parent/child consolidation and fund edges)
 #   - OpenFIGI instruments (ticker -> FIGI mapping)
 #
 # This is a standalone reference schema with no dependencies.
@@ -47,6 +48,17 @@ bulkDownloads:
     comment: >
       GLEIF LEI-CDF 3.1 golden copy CSV download (~450MB compressed, 3.2M records).
       Contains all LEI records worldwide. Shared by gleif_entities and gleif_cik_mapping.
+
+  # GLEIF Relationship Records (RR) golden copy — Level 2 "who owns whom" (~23MB ZIP, ~483k rows)
+  # Separate publish from lei2: LEI-CDF carries no parent/child fields at all, the parent edges
+  # live only here. Same stable permalink form (302 → the current dated file), same 3x/day cadence.
+  gleif_rr_golden_copy:
+    cachePattern: "type=gleif_bulk/gleif-rr-golden-copy.csv.zip"
+    url: "https://goldencopy.gleif.org/api/v2/golden-copies/publishes/rr/latest.csv"
+    dimensions: {}
+    comment: >
+      GLEIF RR-CDF 2.1 golden copy CSV download (~23MB compressed, ~483k relationship
+      records). One row per directed LEI-to-LEI relationship. Used by gleif_relationships.
 
 column_templates:
 
@@ -321,6 +333,332 @@ partitionedTables:
         catalogType: hadoop
         batchPartitionColumns: [type]
         overwritePartitions: true
+        runMaintenance: true
+        snapshotRetentionDays: 1
+        runCompaction: true
+        compactionTargetFileSizeBytes: 134217728
+        compactionMinFiles: 5
+
+  # ==========================================================================
+  # GLEIF RELATIONSHIPS — LEI-to-LEI parent/child edges (RR golden copy)
+  # ==========================================================================
+  - name: gleif_relationships
+    # Same history model as gleif_entities: a full point-in-time golden copy that already carries
+    # a per-record updated_at, so computed_delta appends only the edges whose LastUpdateDate
+    # advanced past the stored high-water mark and registration_last_update becomes the history
+    # axis. Ownership changes are exactly what you want a changelog of — "when did X become a
+    # subsidiary of Y" is answerable from the appended rows, not from any single snapshot.
+    # Columns are 1:1 with the RR CSV, renamed but not reshaped: all five Period / Qualifier /
+    # Quantifier slots are carried as published, so a slot GLEIF starts populating lands in the
+    # table instead of being silently dropped by a selection rule frozen at ingest time. The
+    # collapsing happens in the current_gleif_parents view.
+    dataset_type: computed_delta
+    freshness:
+      type: last_modified   # pre-download gate: skip the pull entirely when the RR file is unchanged
+    pattern: "type=gleif_relationships.parquet"
+    partitions:
+      style: hive
+      columnDefinitions:
+        - name: type
+          type: VARCHAR
+
+    comment: >
+      GLEIF Level 2 relationship records — the LEI-to-LEI edges that LEI-CDF (gleif_entities)
+      does not carry. One row per directed relationship. Both endpoints are always LEIs, so the
+      table self-joins to gleif_entities on either side and, through gleif_cik_mapping, resolves
+      to SEC CIKs. relationship_type values (2026-07-31 publish, 482,849 rows):
+      IS_DIRECTLY_CONSOLIDATED_BY (126,021) and IS_ULTIMATELY_CONSOLIDATED_BY (132,196) are the
+      two levels of the ownership hierarchy; IS_FUND-MANAGED_BY (148,576), IS_SUBFUND_OF (72,731),
+      IS_FEEDER_TO (1,386) are fund structures; IS_INTERNATIONAL_BRANCH_OF (1,939) is branch
+      registration. In every type start_node_id is the subordinate entity and end_node_id is the
+      superior one — but only consolidation means ownership. A fund commonly carries a manager AND
+      an umbrella (59,419 entities; the two are different entities in 60,266 of 60,370 cases): two
+      distinct relations, not two parents.
+      GLEIF flattens the ownership chain to two attested levels and never publishes the
+      intermediate one, so IS_ULTIMATELY_CONSOLIDATED_BY is largely derivable — walking the direct
+      chain reaches the declared ultimate for 113,860 of the 118,627 entities that report both. It
+      is kept because it is REPORTED, not computed: 13,569 entities declare an ultimate with no
+      direct edge to walk from, and 4,765 chains break at an intermediate holding company that has
+      no LEI. Dropping it loses those ~18k attestations.
+      Only entities that report a relationship to GLEIF appear here — an absent edge means "not
+      reported", which the REPEX (reporting exception) publish explains and this table does not
+      carry. Source: GLEIF Golden Copy RR (goldencopy.gleif.org).
+
+    columns:
+      - name: start_node_id
+        type: string
+        nullable: false
+        source: Relationship.StartNode.NodeID
+        comment: LEI of the subordinate entity in the relationship (start_node_id_type is LEI on all 482,849 rows)
+      - name: start_node_id_type
+        type: string
+        nullable: true
+        source: Relationship.StartNode.NodeIDType
+        comment: Node identifier scheme; LEI throughout the current publish
+      - name: end_node_id
+        type: string
+        nullable: false
+        source: Relationship.EndNode.NodeID
+        comment: LEI of the superior entity in the relationship
+      - name: end_node_id_type
+        type: string
+        nullable: true
+        source: Relationship.EndNode.NodeIDType
+        comment: Node identifier scheme; LEI throughout the current publish
+      - name: relationship_type
+        type: string
+        nullable: false
+        source: Relationship.RelationshipType
+        comment: IS_DIRECTLY_CONSOLIDATED_BY, IS_ULTIMATELY_CONSOLIDATED_BY, IS_FUND-MANAGED_BY, IS_SUBFUND_OF, IS_FEEDER_TO, IS_INTERNATIONAL_BRANCH_OF
+      - name: relationship_status
+        type: string
+        nullable: true
+        source: Relationship.RelationshipStatus
+        comment: ACTIVE or INACTIVE
+      # Period slots are NOT positional: a RELATIONSHIP_PERIOD lands in slot 1, 2 or 3 depending on how
+      # many accounting/filing periods the record also carries. Select on period_N_type, never on N.
+      # Slots 4-5 are empty in the current publish; the RR-CDF allows them, so they are carried.
+      - name: period_1_start_date
+        type: string
+        nullable: true
+        source: Relationship.Period.1.startDate
+      - name: period_1_end_date
+        type: string
+        nullable: true
+        source: Relationship.Period.1.endDate
+      - name: period_1_type
+        type: string
+        nullable: true
+        source: Relationship.Period.1.periodType
+      - name: period_2_start_date
+        type: string
+        nullable: true
+        source: Relationship.Period.2.startDate
+      - name: period_2_end_date
+        type: string
+        nullable: true
+        source: Relationship.Period.2.endDate
+      - name: period_2_type
+        type: string
+        nullable: true
+        source: Relationship.Period.2.periodType
+      - name: period_3_start_date
+        type: string
+        nullable: true
+        source: Relationship.Period.3.startDate
+      - name: period_3_end_date
+        type: string
+        nullable: true
+        source: Relationship.Period.3.endDate
+      - name: period_3_type
+        type: string
+        nullable: true
+        source: Relationship.Period.3.periodType
+      - name: period_4_start_date
+        type: string
+        nullable: true
+        source: Relationship.Period.4.startDate
+      - name: period_4_end_date
+        type: string
+        nullable: true
+        source: Relationship.Period.4.endDate
+      - name: period_4_type
+        type: string
+        nullable: true
+        source: Relationship.Period.4.periodType
+      - name: period_5_start_date
+        type: string
+        nullable: true
+        source: Relationship.Period.5.startDate
+      - name: period_5_end_date
+        type: string
+        nullable: true
+        source: Relationship.Period.5.endDate
+      - name: period_5_type
+        type: string
+        nullable: true
+        source: Relationship.Period.5.periodType
+      # ACCOUNTING_STANDARD is the only dimension GLEIF currently publishes; slots 2-5 are near-empty.
+      - name: qualifier_1_dimension
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.1.QualifierDimension
+      - name: qualifier_1_category
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.1.QualifierCategory
+      - name: qualifier_2_dimension
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.2.QualifierDimension
+      - name: qualifier_2_category
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.2.QualifierCategory
+      - name: qualifier_3_dimension
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.3.QualifierDimension
+      - name: qualifier_3_category
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.3.QualifierCategory
+      - name: qualifier_4_dimension
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.4.QualifierDimension
+      - name: qualifier_4_category
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.4.QualifierCategory
+      - name: qualifier_5_dimension
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.5.QualifierDimension
+      - name: qualifier_5_category
+        type: string
+        nullable: true
+        source: Relationship.Qualifiers.5.QualifierCategory
+      # Only slot 1 is populated today, always ACCOUNTING_CONSOLIDATION. Amounts stay strings: 19,232 of
+      # 51,652 are published with no units and some exceed 100 — cast and filter in the query, not here.
+      - name: quantifier_1_method
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.1.MeasurementMethod
+      - name: quantifier_1_amount
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.1.QuantifierAmount
+      - name: quantifier_1_units
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.1.QuantifierUnits
+      - name: quantifier_2_method
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.2.MeasurementMethod
+      - name: quantifier_2_amount
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.2.QuantifierAmount
+      - name: quantifier_2_units
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.2.QuantifierUnits
+      - name: quantifier_3_method
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.3.MeasurementMethod
+      - name: quantifier_3_amount
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.3.QuantifierAmount
+      - name: quantifier_3_units
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.3.QuantifierUnits
+      - name: quantifier_4_method
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.4.MeasurementMethod
+      - name: quantifier_4_amount
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.4.QuantifierAmount
+      - name: quantifier_4_units
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.4.QuantifierUnits
+      - name: quantifier_5_method
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.5.MeasurementMethod
+      - name: quantifier_5_amount
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.5.QuantifierAmount
+      - name: quantifier_5_units
+        type: string
+        nullable: true
+        source: Relationship.Quantifiers.5.QuantifierUnits
+      # --- Registration block: the lifecycle of the relationship RECORD, not of either entity ---
+      - name: registration_initial_date
+        type: string
+        nullable: true
+        source: Registration.InitialRegistrationDate
+      - name: registration_last_update
+        type: string
+        nullable: true
+        source: Registration.LastUpdateDate
+        comment: Last update of the relationship record (ISO 8601) — the computed_delta change key
+      - name: registration_status
+        type: string
+        nullable: true
+        source: Registration.RegistrationStatus
+        comment: PUBLISHED, LAPSED, PENDING_ARCHIVAL or PENDING_TRANSFER — lifecycle of the relationship record itself
+      - name: registration_next_renewal
+        type: string
+        nullable: true
+        source: Registration.NextRenewalDate
+      - name: registration_managing_lou
+        type: string
+        nullable: true
+        source: Registration.ManagingLOU
+        comment: LEI of the Local Operating Unit maintaining the record
+      - name: registration_validation_sources
+        type: string
+        nullable: true
+        source: Registration.ValidationSources
+        comment: FULLY_CORROBORATED, PARTIALLY_CORROBORATED or ENTITY_SUPPLIED_ONLY
+      - name: registration_validation_documents
+        type: string
+        nullable: true
+        source: Registration.ValidationDocuments
+      - name: registration_validation_reference
+        type: string
+        nullable: true
+        source: Registration.ValidationReference
+
+    download:
+      bulkDownload: gleif_rr_golden_copy
+
+    source:
+      type: http
+      url: "https://goldencopy.gleif.org/api/v2/golden-copies/publishes/rr/latest.csv"
+      method: GET
+      extractPattern: "*.csv"
+      incremental:
+        # computed_delta change key: only rows whose registration_last_update exceeds the stored
+        # high-water mark are kept and appended.
+        dateField: registration_last_update
+      response:
+        format: csv
+      rateLimit:
+        requestsPerSecond: 1.0
+        maxRetries: 3
+      rawCache:
+        enabled: true
+
+    dimensions:
+      type:
+        - gleif_relationships
+
+    materialize:
+      enabled: true
+      format: iceberg
+      output:
+        pattern: ""
+      partition:
+        columns: [type]
+      options:
+        compression: snappy
+        batchSize: 50000
+        stagingMode: local
+      iceberg:
+        <<: *compaction_defaults
+        catalogType: hadoop
+        batchPartitionColumns: [type]
+        overwritePartitions: false   # APPEND the computed_delta rows; ownership history is the point
         runMaintenance: true
         snapshotRetentionDays: 1
         runCompaction: true
@@ -1492,6 +1830,26 @@ constraints:
         targetTable: filings
         targetColumns: [cik]
 
+  gleif_relationships:
+    # registration_last_update is part of the key because the table is an append-only changelog: a
+    # given (start node, type) edge appears once per publish in which it was restated. Within a
+    # single publish (start_node_id, relationship_type) is unique — verified on the 2026-07-31
+    # golden copy: 482,849 rows, zero duplicate (start_node_id, relationship_type) pairs.
+    primaryKey: [type, start_node_id, relationship_type, registration_last_update]
+    foreignKeys:
+      - columns: [start_node_id]
+        targetTable: gleif_entities
+        targetColumns: [lei]
+        comment: The subordinate end of the edge — subsidiary, sub-fund, branch or feeder
+      - columns: [end_node_id]
+        targetTable: gleif_entities
+        targetColumns: [lei]
+        comment: The superior end of the edge — consolidating parent, fund manager or umbrella
+      - columns: [registration_managing_lou]
+        targetTable: gleif_entities
+        targetColumns: [lei]
+        comment: LOUs are themselves LEI-registered; links the record's maintainer to its entity
+
   sec_company_tickers:
     primaryKey: [type, as_of, cik]   # per-day snapshots: cik is unique within an as_of, not across
 
@@ -1548,3 +1906,83 @@ views:
         FROM gleif_entities
         GROUP BY lei
       ) latest ON e.lei = latest.lei AND e.last_update = latest.max_last_update
+
+  - name: current_gleif_relationships
+    comment: >
+      Current-state GLEIF relationships: the latest row per (start_node_id, relationship_type)
+      from the append-only gleif_relationships changelog, raw source columns unchanged. Use for
+      "as-now" walks; query gleif_relationships directly (group by registration_last_update) to
+      see when an edge changed.
+    sql: >
+      SELECT r.*
+      FROM gleif_relationships r
+      JOIN (
+        SELECT start_node_id, relationship_type,
+               MAX(registration_last_update) AS max_last_update
+        FROM gleif_relationships
+        GROUP BY start_node_id, relationship_type
+      ) latest ON r.start_node_id = latest.start_node_id
+              AND r.relationship_type = latest.relationship_type
+              AND r.registration_last_update = latest.max_last_update
+
+  - name: current_gleif_parents
+    comment: >
+      The convenience shape over the raw relationship rows — this is where the repeating Period /
+      Qualifier / Quantifier slots are collapsed, deliberately in SQL rather than baked into the
+      stored table, so the selection rules can change without a re-ingest. Restricted to the two
+      ownership types (fund, branch and feeder edges excluded), to ACTIVE relationships whose
+      record is still PUBLISHED, with legal name and jurisdiction resolved on both ends. One row
+      per (child, IS_DIRECTLY_CONSOLIDATED_BY | IS_ULTIMATELY_CONSOLIDATED_BY) — an entity can
+      appear twice, once for its immediate parent and once for the top of its group. Join
+      child_lei or parent_lei to gleif_cik_mapping to reach SEC filers.
+    sql: >
+      SELECT r.start_node_id AS child_lei, ce.legal_name AS child_legal_name,
+             ce.jurisdiction AS child_jurisdiction, r.relationship_type,
+             r.end_node_id AS parent_lei, pe.legal_name AS parent_legal_name,
+             pe.jurisdiction AS parent_jurisdiction,
+             CASE WHEN r.period_1_type = 'RELATIONSHIP_PERIOD' THEN r.period_1_start_date
+                  WHEN r.period_2_type = 'RELATIONSHIP_PERIOD' THEN r.period_2_start_date
+                  WHEN r.period_3_type = 'RELATIONSHIP_PERIOD' THEN r.period_3_start_date
+                  WHEN r.period_4_type = 'RELATIONSHIP_PERIOD' THEN r.period_4_start_date
+                  WHEN r.period_5_type = 'RELATIONSHIP_PERIOD' THEN r.period_5_start_date
+             END AS relationship_start_date,
+             CASE WHEN r.period_1_type = 'ACCOUNTING_PERIOD' THEN r.period_1_end_date
+                  WHEN r.period_2_type = 'ACCOUNTING_PERIOD' THEN r.period_2_end_date
+                  WHEN r.period_3_type = 'ACCOUNTING_PERIOD' THEN r.period_3_end_date
+                  WHEN r.period_4_type = 'ACCOUNTING_PERIOD' THEN r.period_4_end_date
+                  WHEN r.period_5_type = 'ACCOUNTING_PERIOD' THEN r.period_5_end_date
+             END AS accounting_period_end_date,
+             CASE WHEN r.qualifier_1_dimension = 'ACCOUNTING_STANDARD' THEN r.qualifier_1_category
+                  WHEN r.qualifier_2_dimension = 'ACCOUNTING_STANDARD' THEN r.qualifier_2_category
+                  WHEN r.qualifier_3_dimension = 'ACCOUNTING_STANDARD' THEN r.qualifier_3_category
+                  WHEN r.qualifier_4_dimension = 'ACCOUNTING_STANDARD' THEN r.qualifier_4_category
+                  WHEN r.qualifier_5_dimension = 'ACCOUNTING_STANDARD' THEN r.qualifier_5_category
+             END AS accounting_standard,
+             CASE WHEN r.quantifier_1_units = 'PERCENTAGE'
+                  THEN CAST(r.quantifier_1_amount AS DOUBLE) END AS ownership_percentage
+      FROM gleif_relationships r
+      JOIN (
+        SELECT start_node_id, relationship_type,
+               MAX(registration_last_update) AS max_last_update
+        FROM gleif_relationships
+        GROUP BY start_node_id, relationship_type
+      ) lr ON r.start_node_id = lr.start_node_id
+          AND r.relationship_type = lr.relationship_type
+          AND r.registration_last_update = lr.max_last_update
+      LEFT JOIN (
+        SELECT e.lei, e.legal_name, e.jurisdiction
+        FROM gleif_entities e
+        JOIN (
+          SELECT lei, MAX(last_update) AS max_last_update FROM gleif_entities GROUP BY lei
+        ) le ON e.lei = le.lei AND e.last_update = le.max_last_update
+      ) ce ON r.start_node_id = ce.lei
+      LEFT JOIN (
+        SELECT e.lei, e.legal_name, e.jurisdiction
+        FROM gleif_entities e
+        JOIN (
+          SELECT lei, MAX(last_update) AS max_last_update FROM gleif_entities GROUP BY lei
+        ) le ON e.lei = le.lei AND e.last_update = le.max_last_update
+      ) pe ON r.end_node_id = pe.lei
+      WHERE r.relationship_type IN ('IS_DIRECTLY_CONSOLIDATED_BY', 'IS_ULTIMATELY_CONSOLIDATED_BY')
+        AND r.relationship_status = 'ACTIVE'
+        AND r.registration_status = 'PUBLISHED'

--- a/govdata/src/main/resources/sec/sec-schema.yaml
+++ b/govdata/src/main/resources/sec/sec-schema.yaml
@@ -790,6 +790,31 @@ partitionedTables:
         type: string
         nullable: true
         comment: Preferred label role for presentation
+      - name: arc_use
+        type: string
+        nullable: true
+        comment: >-
+          Arc use, "optional" or "prohibited". A prohibited arc states that the relationship
+          does NOT hold — it removes one inherited from a base taxonomy — so a consumer
+          reconstructing the graph must exclude it rather than treat it as an assertion.
+      - name: arc_priority
+        type: int
+        nullable: true
+        comment: >-
+          Arc priority, resolving which arc wins when several share the same from/to and role.
+          Meaningless without arc_use, since its purpose is ordering prohibition against assertion.
+      - name: context_element
+        type: string
+        nullable: true
+        comment: >-
+          xbrldt:contextElement on a hypercube arc, "segment" or "scenario" — which part of the
+          XBRL context the dimension applies to. Definition linkbases only.
+      - name: closed
+        type: boolean
+        nullable: true
+        comment: >-
+          xbrldt:closed on a hypercube arc. When true the hypercube admits only the members it
+          names, so a fact dimensioned outside it is invalid. Definition linkbases only.
 
 
     source:

--- a/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LinkbaseRelationshipLiveTest.java
+++ b/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LinkbaseRelationshipLiveTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.govdata.sec;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reads a real filing's linkbases from EDGAR and checks what comes back.
+ *
+ * <p>The unit tests exercise this parser on linkbases written to demonstrate a rule. Real
+ * linkbases are produced by dozens of filing agents and are where the assumptions actually get
+ * tested — that locators resolve, that an href fragment separates prefix from local name on its
+ * first underscore, that arcs the parser declines to emit really are label and reference arcs.
+ *
+ * <p>Fixed to one filing whose contents will not change: EDGAR filings are immutable once
+ * accepted, so the expected counts below are stable. They were established independently before
+ * this parser existed.
+ */
+@Tag("integration")
+class LinkbaseRelationshipLiveTest {
+
+  private static final String CIK = "0001325676";
+  private static final String ACCESSION = "0001193125-21-093815";
+
+  /** Established from this filing's linkbases before the Java parser was written. */
+  private static final int EXPECTED_TOTAL = 948;
+  private static final int EXPECTED_CALCULATION = 47;
+  private static final int EXPECTED_DEFINITION = 443;
+  private static final int EXPECTED_PRESENTATION = 458;
+
+  private static List<Map<String, Object>> extract() {
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    // Reading linkbases touches no storage; the provider is only used when writing parquet.
+    new XbrlToParquetConverter(null)
+        .extractLinkbaseRelationships(CIK, ACCESSION, "2021-03-26", rows);
+    return rows;
+  }
+
+  private static int countOf(List<Map<String, Object>> rows, String linkbaseType) {
+    int n = 0;
+    for (Map<String, Object> row : rows) {
+      if (linkbaseType.equals(row.get("linkbase_type"))) {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  @Test void testRealFilingYieldsTheExpectedRelationships() {
+    List<Map<String, Object>> rows = extract();
+
+    assertEquals(EXPECTED_TOTAL, rows.size(), "total relationships from all three linkbases");
+    assertEquals(EXPECTED_CALCULATION, countOf(rows, "calculation"));
+    assertEquals(EXPECTED_DEFINITION, countOf(rows, "definition"));
+    assertEquals(EXPECTED_PRESENTATION, countOf(rows, "presentation"));
+  }
+
+  /**
+   * Every locator an arc references must resolve to a concept.
+   *
+   * <p>An unresolved endpoint is dropped rather than written, so this failing would show up as a
+   * quietly short relationship set rather than an error — the shape of loss this whole change
+   * exists to remove.
+   */
+  @Test void testEveryRowHasResolvedEndpoints() {
+    for (Map<String, Object> row : extract()) {
+      String from = (String) row.get("from_concept");
+      String to = (String) row.get("to_concept");
+      assertTrue(from != null && from.contains(":"),
+          "from_concept should be a prefixed name, got " + from);
+      assertTrue(to != null && to.contains(":"),
+          "to_concept should be a prefixed name, got " + to);
+    }
+  }
+
+  /**
+   * Concepts must be spelled the way financial_line_items spells them.
+   *
+   * <p>The two tables are meant to join — that is what reconstructing a statement hierarchy or
+   * checking a rollup requires. The stored data does not currently permit it, because concepts
+   * were written as {@code us-gaapAssets} or {@code loc_us-gaap_Assets}.
+   */
+  @Test void testConceptsUseThePrefixedFormThatJoins() {
+    Set<String> concepts = new HashSet<String>();
+    for (Map<String, Object> row : extract()) {
+      concepts.add((String) row.get("from_concept"));
+      concepts.add((String) row.get("to_concept"));
+    }
+
+    assertTrue(concepts.contains("us-gaap:Liabilities"),
+        "expected a standard us-gaap concept in prefixed form; got e.g. " + firstOf(concepts));
+    for (String concept : concepts) {
+      assertTrue(concept.matches("^[A-Za-z][A-Za-z0-9-]*:[A-Za-z0-9_.-]+$"),
+          "not a prefixed concept name: " + concept);
+    }
+  }
+
+  @Test void testCalculationArcsCarryWeights() {
+    int weighted = 0;
+    for (Map<String, Object> row : extract()) {
+      if ("calculation".equals(row.get("linkbase_type")) && row.get("weight") != null) {
+        weighted++;
+      }
+    }
+    assertEquals(EXPECTED_CALCULATION, weighted,
+        "every summation-item arc states the weight its child contributes");
+  }
+
+  private static String firstOf(Set<String> values) {
+    return values.isEmpty() ? "<none>" : values.iterator().next();
+  }
+}

--- a/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LinkbaseRelationshipTest.java
+++ b/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LinkbaseRelationshipTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.govdata.sec;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for reading relationships out of an XBRL linkbase.
+ *
+ * <p>Relationships are published in linkbase files beside a filing, not inside the filing
+ * document, so a converter reading only the document finds none and writes no rows — silently,
+ * since the filing is still recorded as processed. Measured on 2021, 4,846 of 22,567 annual and
+ * quarterly filings had no relationships for this reason, and reprocessing recovered 5% of them
+ * because re-reading the same document cannot produce what was never in it.
+ */
+@Tag("unit")
+class LinkbaseRelationshipTest {
+
+  private static final String PRESENTATION =
+      "<?xml version='1.0'?>"
+      + "<linkbase xmlns='http://www.xbrl.org/2003/linkbase'"
+      + "          xmlns:xlink='http://www.w3.org/1999/xlink'>"
+      + "  <presentationLink xlink:role='http://acme.com/role/BalanceSheet'>"
+      + "    <loc xlink:href='acme-20211231.xsd#us-gaap_AssetsAbstract' xlink:label='a'/>"
+      + "    <loc xlink:href='acme-20211231.xsd#us-gaap_Assets' xlink:label='b'/>"
+      + "    <presentationArc xlink:arcrole='http://www.xbrl.org/2003/arcrole/parent-child'"
+      + "        xlink:from='a' xlink:to='b' order='1'"
+      + "        preferredLabel='http://www.xbrl.org/2003/role/totalLabel'/>"
+      + "  </presentationLink>"
+      + "</linkbase>";
+
+  private static Document parse(String xml) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(true);
+    return factory.newDocumentBuilder().parse(
+        new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  private static List<Map<String, Object>> read(String xml, String linkbaseType) throws Exception {
+    List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+    // Reading a linkbase touches no storage; the provider is only used when writing parquet.
+    new XbrlToParquetConverter(null).readExtendedLinks(
+        parse(xml), linkbaseType, "0000123456", "0000123456-21-000001", "2021-03-01", 2021, rows);
+    return rows;
+  }
+
+  @Test void testPresentationArcBecomesARelationship() throws Exception {
+    List<Map<String, Object>> rows = read(PRESENTATION, "presentation");
+
+    assertEquals(1, rows.size());
+    Map<String, Object> row = rows.get(0);
+    assertEquals("presentation", row.get("linkbase_type"));
+    assertEquals("http://www.xbrl.org/2003/arcrole/parent-child", row.get("arc_role"));
+    assertEquals("http://acme.com/role/BalanceSheet", row.get("link_role"));
+    assertEquals("us-gaap:AssetsAbstract", row.get("from_concept"));
+    assertEquals("us-gaap:Assets", row.get("to_concept"));
+    assertEquals(Double.valueOf(1), row.get("order"));
+    assertEquals("http://www.xbrl.org/2003/role/totalLabel", row.get("preferred_label"));
+  }
+
+  /**
+   * Every column the schema declares NOT NULL must be filled on every row.
+   *
+   * <p>A row failing this cannot be written, so the filing's whole relationship set is lost at the
+   * point of writing rather than at the point of reading — the failure surfaces far from its cause.
+   */
+  @Test void testRequiredColumnsAreAlwaysPopulated() throws Exception {
+    for (Map<String, Object> row : read(PRESENTATION, "presentation")) {
+      for (String required
+          : new String[] {"cik", "accession_number", "filing_date", "year", "linkbase_type",
+              "arc_role", "from_concept", "to_concept"}) {
+        assertTrue(row.get(required) != null, required + " must not be null");
+      }
+    }
+  }
+
+  /**
+   * Locator labels are scoped to the extended link that declares them.
+   *
+   * <p>The same label names different concepts in two links of one file — filing agents reuse
+   * short labels freely. Building the map per file instead of per link silently attaches arcs to
+   * whichever concept was loaded last, producing relationships that were never filed.
+   */
+  @Test void testLocatorLabelsDoNotLeakBetweenLinks() throws Exception {
+    String xml =
+        "<?xml version='1.0'?>"
+        + "<linkbase xmlns='http://www.xbrl.org/2003/linkbase'"
+        + "          xmlns:xlink='http://www.w3.org/1999/xlink'>"
+        + "  <calculationLink xlink:role='http://acme.com/role/A'>"
+        + "    <loc xlink:href='a.xsd#us-gaap_Assets' xlink:label='x'/>"
+        + "    <loc xlink:href='a.xsd#us-gaap_Cash' xlink:label='y'/>"
+        + "    <calculationArc xlink:arcrole='http://www.xbrl.org/2003/arcrole/summation-item'"
+        + "        xlink:from='x' xlink:to='y' weight='1' order='1'/>"
+        + "  </calculationLink>"
+        + "  <calculationLink xlink:role='http://acme.com/role/B'>"
+        + "    <loc xlink:href='a.xsd#us-gaap_Liabilities' xlink:label='x'/>"
+        + "    <loc xlink:href='a.xsd#us-gaap_AccountsPayable' xlink:label='y'/>"
+        + "    <calculationArc xlink:arcrole='http://www.xbrl.org/2003/arcrole/summation-item'"
+        + "        xlink:from='x' xlink:to='y' weight='-1' order='2'/>"
+        + "  </calculationLink>"
+        + "</linkbase>";
+
+    List<Map<String, Object>> rows = read(xml, "calculation");
+    Map<String, String> byRole = new HashMap<String, String>();
+    for (Map<String, Object> row : rows) {
+      byRole.put((String) row.get("link_role"),
+          row.get("from_concept") + "->" + row.get("to_concept"));
+    }
+
+    assertEquals(2, rows.size());
+    assertEquals("us-gaap:Assets->us-gaap:Cash", byRole.get("http://acme.com/role/A"));
+    assertEquals("us-gaap:Liabilities->us-gaap:AccountsPayable",
+        byRole.get("http://acme.com/role/B"));
+  }
+
+  @Test void testCalculationWeightIsCaptured() throws Exception {
+    String xml = PRESENTATION
+        .replace("presentationLink", "calculationLink")
+        .replace("presentationArc", "calculationArc")
+        .replace("order='1'", "order='1' weight='-1'");
+
+    assertEquals(Double.valueOf(-1), read(xml, "calculation").get(0).get("weight"));
+  }
+
+  /**
+   * A prohibited arc states the relationship does not hold.
+   *
+   * <p>It removes one inherited from a base taxonomy. Dropping the flag would store the arc as an
+   * assertion, so the graph would claim a relationship the filer explicitly deleted.
+   */
+  @Test void testProhibitionIsPreserved() throws Exception {
+    String xml = PRESENTATION.replace("order='1'", "order='1' use='prohibited' priority='2'");
+    Map<String, Object> row = read(xml, "presentation").get(0);
+
+    assertEquals("prohibited", row.get("arc_use"));
+    assertEquals(Integer.valueOf(2), row.get("arc_priority"));
+  }
+
+  @Test void testDimensionalAttributesAreCaptured() throws Exception {
+    String xml =
+        "<?xml version='1.0'?>"
+        + "<linkbase xmlns='http://www.xbrl.org/2003/linkbase'"
+        + "          xmlns:xlink='http://www.w3.org/1999/xlink'"
+        + "          xmlns:xbrldt='http://xbrl.org/2005/xbrldt'>"
+        + "  <definitionLink xlink:role='http://acme.com/role/D'>"
+        + "    <loc xlink:href='a.xsd#us-gaap_StatementTable' xlink:label='t'/>"
+        + "    <loc xlink:href='a.xsd#us-gaap_StatementClassOfStockAxis' xlink:label='d'/>"
+        + "    <definitionArc xlink:arcrole='http://xbrl.org/int/dim/arcrole/hypercube-dimension'"
+        + "        xlink:from='t' xlink:to='d' xbrldt:closed='true'"
+        + "        xbrldt:contextElement='segment' order='1'/>"
+        + "  </definitionLink>"
+        + "</linkbase>";
+
+    Map<String, Object> row = read(xml, "definition").get(0);
+    assertEquals(Boolean.TRUE, row.get("closed"));
+    assertEquals("segment", row.get("context_element"));
+  }
+
+  /**
+   * Label and reference arcs point at documentation, not at a second concept.
+   *
+   * <p>Their target is a resource declared inline rather than a locator, so there is no concept to
+   * put in to_concept. Emitting them anyway is how a relationships table fills with rows whose
+   * endpoints are label stubs — 10.7% of the existing table points at a {@code _lbl} target.
+   */
+  @Test void testArcsToResourcesAreSkipped() throws Exception {
+    String xml =
+        "<?xml version='1.0'?>"
+        + "<linkbase xmlns='http://www.xbrl.org/2003/linkbase'"
+        + "          xmlns:xlink='http://www.w3.org/1999/xlink'>"
+        + "  <labelLink xlink:role='http://www.xbrl.org/2003/role/link'>"
+        + "    <loc xlink:href='a.xsd#us-gaap_Assets' xlink:label='c'/>"
+        + "    <label xlink:label='lbl' xlink:role='http://www.xbrl.org/2003/role/label'>Assets</label>"
+        + "    <labelArc xlink:arcrole='http://www.xbrl.org/2003/arcrole/concept-label'"
+        + "        xlink:from='c' xlink:to='lbl'/>"
+        + "  </labelLink>"
+        + "</linkbase>";
+
+    assertEquals(0, read(xml, "label").size(),
+        "an arc whose target is a label resource is not a relationship between concepts");
+  }
+
+  @Test void testHrefFragmentBecomesAPrefixedConcept() {
+    assertEquals("us-gaap:Assets",
+        XbrlToParquetConverter.conceptFromHref("us-gaap-2021.xsd#us-gaap_Assets"));
+    assertEquals("dei:EntityRegistrantName",
+        XbrlToParquetConverter.conceptFromHref("dei-2021.xsd#dei_EntityRegistrantName"));
+  }
+
+  /**
+   * Only the first underscore separates prefix from local name.
+   *
+   * <p>A company namespace is often the CIK, and local names do contain underscores. Splitting on
+   * the last one, or on all of them, mangles the concept so it no longer joins to
+   * financial_line_items.
+   */
+  @Test void testOnlyTheFirstUnderscoreSeparates() {
+    assertEquals("ck0001325676:SomeMember_Detail",
+        XbrlToParquetConverter.conceptFromHref("x.xsd#ck0001325676_SomeMember_Detail"));
+  }
+
+  @Test void testHrefWithoutFragmentOrSeparator() {
+    assertEquals("Assets", XbrlToParquetConverter.conceptFromHref("Assets"));
+    assertNull(XbrlToParquetConverter.conceptFromHref(null));
+    assertNull(XbrlToParquetConverter.conceptFromHref(""));
+  }
+}

--- a/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LocalNameMatchingTest.java
+++ b/govdata/src/test/java/org/apache/calcite/adapter/govdata/sec/LocalNameMatchingTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.adapter.govdata.sec;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for finding XBRL elements whatever prefix the filer used.
+ *
+ * <p>A traditional XBRL instance writes {@code <xbrli:context>}; once inline XBRL has been
+ * flattened the same element is {@code <context>}. To getElementsByTagName, which matches the
+ * qualified name, those are two different tags — so asking for the bare name skips every prefixed
+ * filing and writes no contexts for it, while still recording the filing as processed.
+ *
+ * <p>That is what happened: filing_contexts coverage of annual and quarterly filings ran from
+ * 41.3% in 2019 to 95.2% in 2023, tracking the retreat of traditional instances rather than
+ * anything about the filings. Reprocessing recovered 10% of the gap, because running the same
+ * lookup over the same document finds the same nothing.
+ */
+@Tag("unit")
+class LocalNameMatchingTest {
+
+  private static final String PREFIXED =
+      "<?xml version='1.0'?>"
+      + "<xbrl xmlns:xbrli='http://www.xbrl.org/2003/instance'>"
+      + "  <xbrli:context id='c1'>"
+      + "    <xbrli:period><xbrli:startDate>2021-01-01</xbrli:startDate>"
+      + "      <xbrli:endDate>2021-12-31</xbrli:endDate></xbrli:period>"
+      + "  </xbrli:context>"
+      + "  <xbrli:context id='c2'>"
+      + "    <xbrli:period><xbrli:instant>2021-12-31</xbrli:instant></xbrli:period>"
+      + "  </xbrli:context>"
+      + "</xbrl>";
+
+  private static final String BARE =
+      "<?xml version='1.0'?>"
+      + "<xbrl>"
+      + "  <context id='c1'>"
+      + "    <period><startDate>2021-01-01</startDate><endDate>2021-12-31</endDate></period>"
+      + "  </context>"
+      + "</xbrl>";
+
+  private static Document parse(String xml, boolean namespaceAware) throws Exception {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(namespaceAware);
+    return factory.newDocumentBuilder().parse(
+        new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test void testPrefixedElementsAreFound() throws Exception {
+    List<Element> contexts =
+        XbrlToParquetConverter.elementsByLocalName(parse(PREFIXED, true), "context");
+
+    assertEquals(2, contexts.size(), "xbrli:context must be found by its local name");
+    assertEquals("c1", contexts.get(0).getAttribute("id"));
+  }
+
+  @Test void testUnprefixedElementsAreStillFound() throws Exception {
+    assertEquals(1,
+        XbrlToParquetConverter.elementsByLocalName(parse(BARE, true), "context").size(),
+        "flattened inline XBRL keeps working");
+  }
+
+  /**
+   * The fallback parser is not namespace aware, so getLocalName returns null there.
+   *
+   * <p>Deriving the local name from the node name instead keeps the same lookup working for a
+   * document that had to be recovered by the lenient parser.
+   */
+  @Test void testWorksWhenTheParserIsNotNamespaceAware() throws Exception {
+    assertEquals(2,
+        XbrlToParquetConverter.elementsByLocalName(parse(PREFIXED, false), "context").size(),
+        "a document parsed without namespace awareness must still match");
+  }
+
+  @Test void testNestedElementsAreFoundWithinAContext() throws Exception {
+    Element context =
+        XbrlToParquetConverter.elementsByLocalName(parse(PREFIXED, true), "context").get(0);
+
+    assertEquals("2021-01-01",
+        XbrlToParquetConverter.elementsByLocalName(context, "startDate").get(0).getTextContent());
+    assertEquals(0, XbrlToParquetConverter.elementsByLocalName(context, "instant").size(),
+        "the first context is a duration, so it has no instant");
+  }
+
+  /**
+   * A local name must not match a different element that merely ends with it.
+   *
+   * <p>{@code endDate} and {@code startDate} both end in "Date"; matching loosely would put a
+   * start date in the period_end column.
+   */
+  @Test void testMatchIsOnTheWholeLocalName() throws Exception {
+    Document doc = parse(PREFIXED, true);
+
+    assertEquals(1, XbrlToParquetConverter.elementsByLocalName(doc, "endDate").size());
+    assertEquals(0, XbrlToParquetConverter.elementsByLocalName(doc, "Date").size());
+    assertEquals(0, XbrlToParquetConverter.elementsByLocalName(doc, "ntext").size());
+  }
+}


### PR DESCRIPTION
## The bug

`incremental.dateField` and `rowFilter.column` are matched against **fetched** rows, which are keyed by raw source field name — the `source:` rename only happens later, during materialization. A config naming the logical column matched nothing, and both settings then degraded **silently** rather than erroring:

- an unresolved `dateField` sent every row down the "no modified value" branch, so `computed_delta` appended the entire source on every run and the high-water mark never advanced;
- an unmatched `rowFilter.column` dropped the filter and admitted every row.

`ref.gleif_entities` hit the first one. It had reached **70,148,421 rows for 3,340,401 distinct LEIs** — roughly 21 stacked copies of the GLEIF registry — while looking like a healthy table.

## The fix

`ColumnConfig.resolveSourceKey()` maps either spelling to the fetch-time key, so the YAML means the same thing whichever the author wrote. `gleif_entities` needed **no YAML change**.

Enforcement sits where there is real evidence, not in an up-front config check:

- the **first fetched row** settles whether the modified field exists at all — absent means the batch fails naming the resolved key and the actual row keys, instead of re-appending the source;
- **`HttpSource`** fails on a filter column absent from the actual CSV headers.

An up-front check was written first and then removed: it cannot tell a typo from a source field that is deliberately never materialized — as in `gleif_cik_mapping`, which filters on `Entity.RegistrationAuthority.RegistrationAuthorityID` and never emits it — and would have rejected working configs.

## New table

`ref.gleif_relationships` — the GLEIF Level 2 edge table. `gleif_entities` carries LEI-CDF only, which has no parent/child fields at all; nothing in govdata held ownership edges. One join table, both endpoints LEIs, `relationship_type` as discriminator. Columns are 1:1 with the RR CSV — renamed, not reshaped, all five repeating slot groups carried as published — with the collapsing done in the `current_gleif_parents` view so the selection rules can change without a re-ingest.

## Verification

- `:file:test` — **14,508 completed, 0 failed**, 23 skipped
- `:govdata:test GovDataSchemaFactoryTest` — 12/12
- Production re-ingest after purge: `computed_delta: modifiedField 'last_update' resolves to source field 'Registration.LastUpdateDate'`, HWM persisted for the first time, and `ref.gleif_entities` is back to **3,340,401 rows / 3,340,401 distinct LEIs**
- `ref.gleif_relationships` first ingest: 482,824 rows, compacted to one 16.8 MB file

## Behaviour changes to review

`testParseDelimitedResponseFilterColumnNotFound` in `HttpSourceCoverageTest` and `HttpSourceDeepCoverageTest3` asserted that an unmatched filter column lets every row through. They encoded the silent degradation as correct; both now assert the failure.

## ⚠️ Contains one unrelated commit

`439c7ec45 perf(file): skip the committed-accession scan when the Iceberg snapshot is unchanged` was committed to this branch by a concurrent session while I was working in the same tree. It is unrelated to everything above and I have not restructured it. Split it out before merging if you want it reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)